### PR TITLE
Fix docked→idle restore flash (snap WAVE→BREATH while strip is dark)

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Test/ARCHITECTURE.md
+++ b/variants/block-kit/firmware/BlockKit_Test/ARCHITECTURE.md
@@ -66,7 +66,7 @@ Mist drive: 108.7 kHz / 0–50 % PWM into a piezo disc. Container has a magnet t
                  │   mist hard-stopped                         │
                  │   wave still rendering, dims to 0 (~0.85 s) │
                  │   auto-enters IDLE →                        │
-                 │   WAVE→BREATH crossfade (1.1 s) +           │
+                 │   WAVE→BREATH mode SNAP (strip is dark) +   │
                  │   fast level restore (~0.64 s)              │
                  └─────┬───────────────────────────────────────┘
                        │ smoother reaches 0
@@ -88,7 +88,7 @@ handles any mode swap mid-fade — no special case needed).
 |---|---|---|
 | IDLE → RUNNING | reed Inserted (500 ms dwell) | mist on (wave-modulated), mode = WAVE → 1.1 s BREATH→WAVE crossfade in pre-gamma space |
 | RUNNING → TRANSITION_FROM_RUNNING | reed Removed (100 ms dwell) | **mist hard-stop**; mode stays WAVE, baseLevel ramps 255→0 (~0.85 s) — wave dims naturally |
-| TRANSITION_FROM_RUNNING → IDLE | smoother lands on 0 | mode→BREATH (kicks off WAVE→BREATH crossfade), fast fade-up to `g_userLevel` (~0.64 s) |
+| TRANSITION_FROM_RUNNING → IDLE | smoother lands on 0 | mode→BREATH via `ledSetModeSnap` (no crossfade — strip is dark, so the snap is invisible). Fast fade-up to `g_userLevel` (~0.64 s) |
 | TRANSITION_FROM_RUNNING → RUNNING | reed re-Inserted mid-fade | crossfade engine handles WAVE→WAVE no-op; mist re-armed |
 | any state | button short-press | toggles `g_ledsHidden` (LED render fades to/from 0; mist + state untouched) |
 | IDLE / RUNNING | button long-press | ramps `g_userLevel`; mist + LED brightness scale live (wave traverse rate stays constant) |
@@ -149,7 +149,7 @@ Pieces sitting outside the smoother:
 |---|---|
 | Power on | Boots to `IDLE` with LEDs visible — strip starts a deep-dim exp(sin) breath; the exhale dwells at full black for a beat each cycle |
 | Dock container | ~500 ms reed dwell → mist on (wave-modulated at the piezo); mode flips to WAVE, the dim breath dissolves into the slow gaussian swell over 1.1 s (single continuous crossfade). Mist visibly pulses in sync with the LED swell. |
-| Lift container | Mist hard-stops instantly. Wave dims to black over ~0.85 s (mode stays WAVE so it reads as continuous), then the dim breath crossfades back in over 1.1 s |
+| Lift container | Mist hard-stops instantly. Wave dims to black over ~0.85 s (mode stays WAVE so it reads as continuous). At black, mode SNAPS to BREATH (invisible since strip is dark — avoids a crossfade flash where WAVE's higher raw output would briefly dominate as baseLevel rose), then the dim breath fades in cleanly (~0.64 s) |
 | Tap button (any state) | Toggles `g_ledsHidden` — LED strip fades to dark (or back in) over ~640 ms. **Mist is not affected** — if a container is docked, the diffuser keeps running at the user-set level even while the strip is hidden |
 | Hold button (IDLE or RUNNING) | Ramps `g_userLevel` — brightness scales live and mist drive scales with it (still wave-modulated in RUNNING). Wave traverse rate stays constant. Direction alternates on release. The ramp clamps at 0 / 255 — there is no auto-snap-to-off; long-pressing to 0 just leaves the device at level 0 (mist off, LEDs dark), and the next long-press in the opposite direction brings it back. |
 

--- a/variants/block-kit/firmware/BlockKit_Test/BlockKit_Test.ino
+++ b/variants/block-kit/firmware/BlockKit_Test/BlockKit_Test.ino
@@ -75,7 +75,7 @@ void containerInit(); bool containerIsPresent(); bool containerRawPresent();
 ContainerEvent containerPoll();
 void buttonInit();    ButtonEvent buttonPoll();
 void ledInit(); void ledRender(uint8_t); void ledAllOff(); void ledWalk();
-void ledSetMode(LedMode);
+void ledSetMode(LedMode); void ledSetModeSnap(LedMode);
 uint8_t waveIntensityAtPiezo(uint32_t now);
 void statusLedInit(); void statusLedSet(bool);
 void currentSenseInit(); void currentSenseTick();
@@ -129,19 +129,35 @@ static bool mistMayBeActive(AppState s) {
 
 static void enterIdle() {
   // Special wiring: when called from TRANSITION_FROM_RUNNING, the breath
-  // restore uses a faster smoother step — capture that BEFORE the
-  // idempotency check so the flag flips even if we somehow call it twice
-  // in the same frame.
+  // restore uses a faster smoother step AND must snap the mode swap (see
+  // below) — capture that BEFORE the idempotency check so the flag flips
+  // even if we somehow call it twice in the same frame.
   const bool fromTransition = (g_state == AppState::TRANSITION_FROM_RUNNING);
   if (g_state == AppState::IDLE) return;
   const bool leavingMist = mistMayBeActive(g_state);
   g_state = AppState::IDLE;
   g_targetLevel = g_userLevel;
   g_fastFadeUp = fromTransition;
-  // BREATH triggers the WAVE→BREATH crossfade in led_driver when coming
-  // from RUNNING / TRANSITION. led_driver collapses no-op mode changes
-  // for us if we were already BREATH (e.g. boot).
-  ledSetMode(LedMode::BREATH);
+  if (fromTransition) {
+    // We just finished dimming the wave to baseLevel=0 — the strip is
+    // currently invisible. SNAP WAVE→BREATH instead of crossfading.
+    //
+    // A normal crossfade here flashes the strip: led_driver keeps
+    // rendering WAVE (raw 92..255) blended with BREATH (raw 0..LED_BREATH_PEAK)
+    // while the smoother ramps baseLevel back up to user_level. WAVE's
+    // much higher raw output dominates the blend mid-restore, producing
+    // a transient peak well above the idle steady-state before the
+    // crossfade tilts to BREATH (≈23 % PWM peak vs ≈4 % steady at the
+    // current LED_BREATH_PEAK=80 — the user-reported "quick flash").
+    // Snapping the mode while strip is dark makes the swap invisible,
+    // then BREATH fades in cleanly on its own with no wave bleed-through.
+    ledSetModeSnap(LedMode::BREATH);
+  } else {
+    // From any other state (e.g. boot): mode was already BREATH or this
+    // is the first frame after init — led_driver collapses redundant
+    // mode changes for us.
+    ledSetMode(LedMode::BREATH);
+  }
   if (leavingMist) mistEnable(false);
   Serial.println("[APP] -> IDLE");
 }

--- a/variants/block-kit/firmware/BlockKit_Test/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Test/led_driver.ino
@@ -188,6 +188,21 @@ void ledSetMode(LedMode m) {
   g_crossfadeStartMs = millis(); // start the blend window
 }
 
+// Snap to a new mode WITHOUT starting a crossfade. Only call when you know
+// the strip is currently invisible (baseLevel = 0) — otherwise the swap
+// will be jarring. The motivating case is the docked→idle restore: when
+// the smoother lands at baseLevel=0 we want to swap WAVE→BREATH then fade
+// up the breath. A normal crossfade here causes a visible flash because
+// the engine keeps rendering WAVE (raw 92..255) blended with BREATH (raw
+// 0..130) while baseLevel rises — the higher-raw WAVE briefly dominates
+// the blend and produces a transient brightness peak above the idle
+// steady-state. Snap makes the swap invisible (since baseLevel=0 maps
+// any raw to 0 after gamma) and lets the breath fade in cleanly.
+void ledSetModeSnap(LedMode m) {
+  g_ledMode  = m;
+  g_prevMode = m;                // prev == current → ledRender skips blend
+}
+
 // ---- Render helpers ------------------------------------------------------
 //
 // Both renderers produce per-LED raw 0..255 brightness in *pre-gamma, pre-


### PR DESCRIPTION
## Summary

**Single-commit, single-purpose:** fix the "quick flash" the user saw on the docked→idle transition (after lifting the piezo disc).

`LED_BREATH_PEAK` on main and every other tunable is **unchanged** — this PR only adds `ledSetModeSnap()` and uses it in `enterIdle()`.

## Root cause

When the wave finished dimming to `baseLevel=0` and the smoother auto-entered `IDLE`, the prior code called `ledSetMode(BREATH)` which kicked off a 1.1 s WAVE→BREATH crossfade. The fast level-restore then ramped `baseLevel` 0→255 in only ~640 ms — *while the crossfade was still running*. The blend engine kept rendering both modes:

```
mid-restore (baseLevel=255, crossfade 58% in):
  blended_raw = 0.42×WAVE(255) + 0.58×BREATH(LED_BREATH_PEAK)
  output = GAMMA[blended_raw × baseLevel/255]
        ≈ 60/255 ≈ 23 % PWM       ← FLASH
  steady-state idle peak ≈  4 % PWM (at LED_BREATH_PEAK=80)
```

WAVE's much higher raw output briefly dominated the blend mid-restore, producing a transient brightness peak well above the steady-state idle.

## Fix

New `ledSetModeSnap(LedMode)` in `led_driver.ino` flips the mode without starting a crossfade (sets `g_prevMode = g_ledMode = new`). In `enterIdle()` use it on the `fromTransition` path — strip is dark at that moment, so the swap is invisible, and BREATH fades in on its own with no wave bleed-through.

Other transitions (IDLE→RUNNING, mode swaps mid-fade, etc.) still use the normal crossfade — `ledSetModeSnap` is specifically for paths where the strip is known dark.

## Diff scope

- `led_driver.ino` — adds `ledSetModeSnap()` (15 lines below `ledSetMode`).
- `BlockKit_Test.ino` — adds forward decl; replaces 1-line `ledSetMode` call in `enterIdle()` with conditional snap-or-crossfade.
- `ARCHITECTURE.md` — updates the cinematic description (snap not crossfade) on the docked→idle path.

3 files, +42 / -11. No `pins.h` changes — main's LED config is preserved.

## Test plan

- [ ] Reflash from this branch.
- [ ] Lift container during RUNNING: mist cuts; wave dims smoothly to black; **no flash on the way back to breath**; idle breath resumes cleanly.
- [ ] Re-dock during the wind-down: WAVE re-engages via crossfade engine (unchanged).
- [ ] Idle ↔ RUNNING transitions otherwise unchanged.
- [ ] Short-press LED hide / show transitions unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7J2tNS4AFPrghey63fcre)_