### PR TITLE
Sync mist drive to LED wave; short-press hides LEDs only

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Test/ARCHITECTURE.md
+++ b/variants/block-kit/firmware/BlockKit_Test/ARCHITECTURE.md
@@ -42,63 +42,64 @@ Mist drive: 108.7 kHz / 0–50 % PWM into a piezo disc. Container has a magnet t
 
 ```
                      ┌────────────────────────────┐
-                     │ IDLE_LEDS_ON (boot)        │
+                     │ IDLE (boot, LEDs visible)  │
                      │ strip = BREATH             │
                      │ deep-dim exp(sin) pulse;   │
                      │ exhale lingers at black    │
+                     │ mist off                   │
                      └────┬───────────────────────┘
-                          │ short-press ▲ / ▼ short-press
-                     ┌────▼────────────────┐
-                     │ IDLE_LEDS_OFF       │
-                     │ strip dark          │
-                     └─────────────────────┘
+                          │ container docked (500 ms dwell)
+                          ▼ (BREATH→WAVE crossfade, 1.1 s)
+                 ┌─────────────────────────────────────────────┐
+                 │ RUNNING                                     │
+                 │   strip = WAVE: every LED always lit,       │
+                 │   single broad gaussian swell traveling     │
+                 │   bottom→top over 7.5 s (slow, meditative). │
+                 │   mist on, modulated by the swell at the    │
+                 │   piezo position (1 LED above index 0)      │
+                 │   D7 off                                    │
+                 └─────┬───────────────────────────────────────┘
+                       │ container removed
+                       ▼
+                 ┌─────────────────────────────────────────────┐
+                 │ TRANSITION_FROM_RUNNING                     │
+                 │   mist hard-stopped                         │
+                 │   wave still rendering, dims to 0 (~0.85 s) │
+                 │   auto-enters IDLE →                        │
+                 │   WAVE→BREATH crossfade (1.1 s) +           │
+                 │   fast level restore (~0.64 s)              │
+                 └─────┬───────────────────────────────────────┘
+                       │ smoother reaches 0
+                       ▼
+                      IDLE
 
-  IDLE_LEDS_ON / IDLE_LEDS_OFF
-        │ container docked (500 ms dwell)
-        ▼ (BREATH→WAVE crossfade, 1.1 s)
-  ┌─────────────────────────────────────────────┐
-  │ RUNNING                                     │
-  │   strip = WAVE: every LED always lit,       │
-  │   single broad gaussian swell traveling     │
-  │   bottom→top over 7.5 s (slow, meditative). │
-  │   mist on, D7 off                           │
-  └─────┬───────────────────────────────────────┘
-        │ container removed
-        ▼
-  ┌─────────────────────────────────────────────┐
-  │ TRANSITION_FROM_RUNNING                     │
-  │   mist hard-stopped                         │
-  │   wave still rendering, dims to 0 (~0.85 s) │
-  │   auto-enters IDLE_LEDS_ON →                │
-  │   WAVE→BREATH crossfade (1.1 s) +           │
-  │   fast level restore (~0.64 s)              │
-  └─────┬───────────────────────────────────────┘
-        │ smoother reaches 0
-        ▼
-       IDLE_LEDS_ON
+  Orthogonal short-press LED hide flag (any state):
+     g_ledsHidden=false  ─── short-press ──►  g_ledsHidden=true
+     LEDs visible (~640 ms fade)              LEDs dark, mist untouched
 ```
 
-Short-press from any active state → `IDLE_LEDS_OFF` (mute, skips cinematic).
-Re-docking during `TRANSITION_FROM_RUNNING` cleanly re-enters `RUNNING` (the
-crossfade engine handles any mode swap mid-fade — no special case needed).
+Short-press toggles `g_ledsHidden` in any state — the LED render fades to/from 0
+over ~640 ms, but mist behavior is unaffected (so the diffuser keeps running at
+the user-set level even while the visuals are blanked). Re-docking during
+`TRANSITION_FROM_RUNNING` cleanly re-enters `RUNNING` (the crossfade engine
+handles any mode swap mid-fade — no special case needed).
 
 | From → To | Trigger | Effect |
 |---|---|---|
-| IDLE → RUNNING | reed Inserted (500 ms dwell) **or** button short-press + container docked | mist on, mode = WAVE → 1.1 s BREATH→WAVE crossfade in pre-gamma space |
+| IDLE → RUNNING | reed Inserted (500 ms dwell) | mist on (wave-modulated), mode = WAVE → 1.1 s BREATH→WAVE crossfade in pre-gamma space |
 | RUNNING → TRANSITION_FROM_RUNNING | reed Removed (100 ms dwell) | **mist hard-stop**; mode stays WAVE, baseLevel ramps 255→0 (~0.85 s) — wave dims naturally |
-| TRANSITION_FROM_RUNNING → IDLE_LEDS_ON | smoother lands on 0 | mode→BREATH (kicks off WAVE→BREATH crossfade), fast fade-up to `g_userLevel` (~0.64 s) |
-| RUNNING / TRANSITION → IDLE_LEDS_OFF | button short-press | snap to mute (skips cinematic) |
-| IDLE_LEDS_OFF ↔ IDLE_LEDS_ON | button short-press (no container) | dim breath fades in/out (mode stays BREATH; no crossfade) |
-| RUNNING / IDLE_LEDS_ON | button long-press | ramps `g_userLevel`; brightness scales live (wave traverse rate stays constant) |
-| any | level dims past `LEVEL_OFF_THRESHOLD` (8) | snap to `IDLE_LEDS_OFF`, reset `userLevel = LEVEL_DEFAULT`, flip ramp direction |
+| TRANSITION_FROM_RUNNING → IDLE | smoother lands on 0 | mode→BREATH (kicks off WAVE→BREATH crossfade), fast fade-up to `g_userLevel` (~0.64 s) |
+| TRANSITION_FROM_RUNNING → RUNNING | reed re-Inserted mid-fade | crossfade engine handles WAVE→WAVE no-op; mist re-armed |
+| any state | button short-press | toggles `g_ledsHidden` (LED render fades to/from 0; mist + state untouched) |
+| IDLE / RUNNING | button long-press | ramps `g_userLevel`; mist + LED brightness scale live (wave traverse rate stays constant) |
 
 ## Level Model (the trick)
 
-One scalar drives both mist and LEDs so they always move together.
+One scalar drives both mist and LEDs so they always move together. A separate, orthogonal scaler hides the LED strip without touching the mist.
 
 ```
 g_userLevel    (0..255)   ← user's intent; long-press ramps this
-g_targetLevel  (0..255)   ← state-driven goal (0 in IDLE_LEDS_OFF /
+g_targetLevel  (0..255)   ← state-driven goal (0 in
                             TRANSITION_FROM_RUNNING, g_userLevel otherwise)
 g_currentLevel (0..255)   ← smoothed actual; ramps toward target +2 / 10 ms
                             (≈ 1.3 s 0→255). Step size is intentionally tiny
@@ -107,8 +108,21 @@ g_currentLevel (0..255)   ← smoothed actual; ramps toward target +2 / 10 ms
                             Post-removal breath restore uses STEP_UP_FAST
                             (~0.64 s) so the cinematic stays brisk.
 
-mist duty   = (g_currentLevel × MIST_DUTY_MAX) / 255    // 127 = 50 %
-LED bright  = led_driver(g_currentLevel, g_ledMode)
+g_ledsHidden   (bool)     ← short-press toggle; orthogonal to state
+g_ledScale     (0..255)   ← smoothed visibility scaler; eases toward
+                            g_ledScaleTarget = (g_ledsHidden ? 0 : 255)
+                            over ~640 ms (step 4 / 10 ms). Multiplies the
+                            baseLevel handed to ledRender; mist ignores it.
+
+mist duty   = (computeMistOutLevel(g_currentLevel, now) × MIST_DUTY_MAX) / 255
+              where computeMistOutLevel(level, now) applies the wave-sync
+              factor:
+                factor (Q8) = MIST_WAVE_TROUGH_Q8
+                            + ((256 - MIST_WAVE_TROUGH_Q8) × gauss_at_piezo) >> 8
+                gauss_at_piezo = waveIntensityAtPiezo(now)  // 0..255
+              In any state other than RUNNING, mist is inhibited (boost
+              rail down) so the value is don't-care.
+LED bright  = led_driver((g_currentLevel × g_ledScale) >> 8, g_ledMode)
               where led_driver:
                 BREATH:  exp(sin) curve LUT, capped to LED_BREATH_PEAK (raw
                          80 → PWM 10/255 ≈ 4 %) so idle stays dim regardless
@@ -124,30 +138,29 @@ LED bright  = led_driver(g_currentLevel, g_ledMode)
 
 Pieces sitting outside the smoother:
 - **Reed lift** → `mistHardStop()` cuts boost rail + PWM immediately and sets an inhibit flag so the still-fading `g_currentLevel` can't re-engage the boost. `enterRunning()` clears the inhibit.
-- **D7** is driven once per loop from `containerIsPresent()` — independent of `state` and `level`.
+- **Wave-mist sync** → in `RUNNING`, mist drive is *additionally* modulated by `waveIntensityAtPiezo(now)`, which samples the wave's gaussian 1 LED above the top of the strip (where the piezo sits). Same `now` is fed to the visible WAVE renderer, so the mist crest you feel is the wave crest you see, delayed only by the geometry of the piezo sitting above the top LED.
+- **Short-press LED hide** → toggles `g_ledsHidden`. `g_ledScale` smooths in/out over ~640 ms and multiplies the baseLevel handed to `ledRender`. Mist drive does not pass through this scaler, so blanking the visuals never stops the diffuser.
+- **D7** is driven once per loop from `containerIsPresent()` — independent of `state`, `level`, and `g_ledsHidden`.
 - **led_driver crossfade engine** — `ledSetMode()` captures the prior mode and starts a `LED_CROSSFADE_MS` timer. While elapsed < timer, both modes render every frame and outputs are linearly blended per LED in pre-gamma space. Replaces the prior `g_pendingSwirl` state-machine flag — the BREATH↔WAVE swap is now a single continuous dissolve, not "fade up then snap".
 
 ## User Interactions
 
 | User does | Result |
 |---|---|
-| Power on | Boots to `IDLE_LEDS_ON` — strip starts a deep-dim exp(sin) breath; the exhale dwells at full black for a beat each cycle |
-| Dock container | ~500 ms reed dwell → mist on; mode flips to WAVE, the dim breath dissolves into the slow gaussian swell over 1.1 s (single continuous crossfade) |
+| Power on | Boots to `IDLE` with LEDs visible — strip starts a deep-dim exp(sin) breath; the exhale dwells at full black for a beat each cycle |
+| Dock container | ~500 ms reed dwell → mist on (wave-modulated at the piezo); mode flips to WAVE, the dim breath dissolves into the slow gaussian swell over 1.1 s (single continuous crossfade). Mist visibly pulses in sync with the LED swell. |
 | Lift container | Mist hard-stops instantly. Wave dims to black over ~0.85 s (mode stays WAVE so it reads as continuous), then the dim breath crossfades back in over 1.1 s |
-| Tap button (no container) | Toggles deep-dim BREATH on / off |
-| Tap button (any active state) | Snaps to `IDLE_LEDS_OFF` (skips the removal cinematic if mid-transition) |
-| Tap button when muted, container docked | Resumes RUNNING (BREATH→WAVE crossfade from black) |
-| Hold button (RUNNING or IDLE_LEDS_ON) | Ramps `g_userLevel` — brightness scales live. Wave traverse rate stays constant in RUNNING (dim is brightness-only). Direction alternates on release |
-| Hold button past `LEVEL_OFF_THRESHOLD` (8) | Auto-snap to `IDLE_LEDS_OFF`, user level resets to default so the next wake comes back at full |
+| Tap button (any state) | Toggles `g_ledsHidden` — LED strip fades to dark (or back in) over ~640 ms. **Mist is not affected** — if a container is docked, the diffuser keeps running at the user-set level even while the strip is hidden |
+| Hold button (IDLE or RUNNING) | Ramps `g_userLevel` — brightness scales live and mist drive scales with it (still wave-modulated in RUNNING). Wave traverse rate stays constant. Direction alternates on release. The ramp clamps at 0 / 255 — there is no auto-snap-to-off; long-pressing to 0 just leaves the device at level 0 (mist off, LEDs dark), and the next long-press in the opposite direction brings it back. |
 
 ## Files
 
 | File | Role |
 |---|---|
-| `BlockKit_Test.ino` | state machine, smoother, serial parser, glue |
+| `BlockKit_Test.ino` | state machine, smoother, LED-visibility smoother, wave-mist sync (`computeMistOutLevel`), serial parser, glue |
 | `pins.h` | pin defs, tunables, enums — single source of truth |
 | `mist.ino` | `mistApply(level)`, `mistHardStop`, boost rail gating, inhibit |
-| `led_driver.ino` | `ledRender(baseLevel)` — renders BREATH (exp(sin) LUT, linear-interp, capped to LED_BREATH_PEAK) or WAVE (gaussian-LUT swell traveling bottom→top), 1.1 s pre-gamma crossfade between modes, gamma + per-LED I2C write cache |
+| `led_driver.ino` | `ledRender(baseLevel)` — renders BREATH (exp(sin) LUT, linear-interp, capped to LED_BREATH_PEAK) or WAVE (gaussian-LUT swell traveling bottom→top), 1.1 s pre-gamma crossfade between modes, gamma + per-LED I2C write cache. Also exposes `waveIntensityAtPiezo(now)` so the main loop can phase-lock mist drive to the wave swell. |
 | `status_led.ino` | D7 dim-on / off |
 | `container.ino` | reed debounce, edge events |
 | `button.ino` | debounce, short/long-press events |
@@ -160,7 +173,7 @@ Arduino concatenates all `.ino` files into one translation unit, so file-scope `
 | Cmd | Effect |
 |---|---|
 | `help` | print list |
-| `1` / `0` / `t` | mist on / off / toggle |
+| `l` / `L` / `t` | hide LEDs / show LEDs / toggle visibility (mist untouched) |
 | `vN` | set `g_userLevel` 0..255 |
 | `w` | LED walk (sequence 14 LEDs, ~14 s, blocks) |
 | `r` | dump reed state (raw + debounced) |
@@ -176,10 +189,12 @@ Log line prefixes: `[APP]`, `[MIST]`, `[LED]`, `[REED]`, `[BTN]`, `[CUR]`, `[STA
 |---|---|---|
 | `MIST_FREQ_HZ` | 108 700 | Piezo disc resonance |
 | `MIST_DUTY_MAX` | 127 | 50 % of 8-bit PWM = full mist |
+| `MIST_PIEZO_OFFSET_LEDS_Q8` | 256 | Piezo position above index 0 (1 LED) for the wave-mist sync gauss sample |
+| `MIST_WAVE_TROUGH_Q8` | 92 | Mist trough factor (92/256 ≈ 36 %) — matches `WAVE_BASE_LEVEL` / 255 so the mist's swing mirrors the LED's |
 | `LEVEL_DEFAULT` | 255 | First-boot mist + brightness |
 | `LEVEL_SMOOTH_TICK_MS` / `STEP_UP` / `STEP_DN` | 10 / 2 / 3 | ~1.3 s fade-in, ~0.85 s fade-out — tiny steps so the slide reads as continuous |
 | `LEVEL_SMOOTH_STEP_UP_FAST` | 4 | ~0.64 s breath restore after removal — keeps the cinematic brisk |
-| `LEVEL_OFF_THRESHOLD` | 8 | Snap-to-off cutoff during dim ramp |
+| `LED_SCALE_STEP_PER_TICK` | 4 | ~0.64 s short-press LED hide/show fade |
 | `LED_BREATH_PEAK` | 80 | raw cap on breath sweep → PWM 10/255 ≈ 4 % post-gamma. Picked so the sweep covers ~10 distinct PWM levels (smooth gradient) instead of the 1 level peak=38 gave (blink-like). |
 | `LED_BREATH_PERIOD_MS` | 5500 | One slow inhale → exhale → black-dwell |
 | `WAVE_BASE_LEVEL` | 92 | Always-on baseline every LED holds (docked) |

--- a/variants/block-kit/firmware/BlockKit_Test/BlockKit_Test.ino
+++ b/variants/block-kit/firmware/BlockKit_Test/BlockKit_Test.ino
@@ -5,25 +5,35 @@
 // dim indicator + scope-mode current logging. The water-level classifier
 // (Phase B) is intentionally NOT in this build.
 //
-// State machine — four states, all centralized here:
+// State machine — three container-driven states, plus an orthogonal
+// `g_ledsHidden` boolean that's toggled by the short-press button:
 //
-//   IDLE_LEDS_OFF           — muted: LEDs dark. Reached only via short-press.
-//   IDLE_LEDS_ON            — DEFAULT idle: container undocked, LED strip
+//   IDLE                    — DEFAULT idle: container undocked, LED strip
 //                             holding a *very dim, dramatic* exp(sin) breath
 //                             — the exhale lingers at full black for a beat.
 //                             Boot lands here.
-//   RUNNING                 — container docked, mist active. LED strip runs
-//                             the WAVE animation: every LED always lit at a
-//                             baseline, plus a single slow gaussian swell
-//                             traveling bottom→top. The BREATH→WAVE swap
-//                             on docking is a 1.1 s crossfade — no snap.
+//   RUNNING                 — container docked, mist active and PULSING in
+//                             sync with the LED wave (see "Wave-mist sync"
+//                             below). LED strip runs the WAVE animation:
+//                             every LED always lit at a baseline, plus a
+//                             single slow gaussian swell traveling bottom→
+//                             top. The BREATH→WAVE swap on docking is a
+//                             1.1 s crossfade — no snap.
 //   TRANSITION_FROM_RUNNING — container just lifted: mist hard-stopped,
 //                             wave dims to 0 (mode stays WAVE during the dim
 //                             so it reads as continuous), then auto-enters
-//                             IDLE_LEDS_ON which kicks off the WAVE→BREATH
+//                             IDLE which kicks off the WAVE→BREATH
 //                             crossfade as the breath fades back in. Re-
 //                             docking during this transition cleanly re-
 //                             enters RUNNING.
+//
+// Orthogonal: `g_ledsHidden` (short-press toggle) hides the LED strip only.
+// The mist keeps running at the user-set level regardless of the flag, so
+// short-pressing is *not* a kill switch — it's a "blank the visuals,
+// please" gesture. A separate smoother fades the LED render to 0 over
+// ~640 ms (the wave/breath animation keeps running underneath). The
+// previous design coupled "mute LEDs" with "stop mist"; the new design
+// lets you keep the diffuser working while the room goes dark.
 //
 // One `g_userLevel` variable (0..255) drives both mist PWM duty and LED
 // brightness scale. Mist duty = (level * MIST_DUTY_MAX) / 255 so level=255
@@ -31,6 +41,19 @@
 // level to be; `smoothLevel()` ramps `g_currentLevel` toward target with
 // step=2 per 10 ms tick (~1.3 s 0→255) so every fade feels continuous, not
 // stepped — addressing the prior "snappy" complaint.
+//
+// Wave-mist sync (RUNNING only):
+//   While in RUNNING, the mist drive level is no longer just g_currentLevel.
+//   It's modulated by the wave's gaussian swell evaluated 1 LED *above*
+//   the top of the strip — where the piezo disc physically sits. Result:
+//   the mist rises as the swell rises up the LEDs, peaks once the wave has
+//   visibly crossed the top (because that's when the wave reaches the
+//   piezo), then dims down together with the top LED as the wave continues
+//   off-screen above. At max user level the mist swings between ~36 % and
+//   100 % of full — visible pulse, but proportional to the wave's own
+//   trough-to-peak ratio so the two motions feel like one motion. See
+//   `computeMistOutLevel()` below and `waveIntensityAtPiezo()` in
+//   led_driver.ino.
 //
 // Container lift is a SAFETY event: mist hard-stops the moment the reed
 // opens (mistHardStop), while the LED smoother continues the visual fade.
@@ -53,6 +76,7 @@ ContainerEvent containerPoll();
 void buttonInit();    ButtonEvent buttonPoll();
 void ledInit(); void ledRender(uint8_t); void ledAllOff(); void ledWalk();
 void ledSetMode(LedMode);
+uint8_t waveIntensityAtPiezo(uint32_t now);
 void statusLedInit(); void statusLedSet(bool);
 void currentSenseInit(); void currentSenseTick();
 void currentSenseLogPlot(uint8_t); void currentSenseToggleScope();
@@ -60,7 +84,7 @@ void currentSenseTogglePlotMute();
 float currentMeanMa(); float currentVarMa2();
 
 // ---- App-level state ----
-static AppState g_state           = AppState::IDLE_LEDS_ON;  // boot default = soft breath
+static AppState g_state           = AppState::IDLE;  // boot default = soft breath
 static uint8_t  g_userLevel       = LEVEL_DEFAULT;   // user's set level (long-press adjusts)
 static uint8_t  g_targetLevel     = 0;               // state-driven target for the smoother
 static uint8_t  g_currentLevel    = 0;               // smoothed actual level applied to mist+LEDs
@@ -69,13 +93,23 @@ static uint32_t g_lastSmoothMs    = 0;
 static uint32_t g_lastRampMs      = 0;
 static uint32_t g_lastStatMs      = 0;
 // One-shot flag: use the fast STEP_UP for the next 0→target ramp. Set when
-// entering IDLE_LEDS_ON from TRANSITION_FROM_RUNNING so the breath restore
+// entering IDLE from TRANSITION_FROM_RUNNING so the breath restore
 // after a container lift feels brisk (~640 ms) rather than luxurious (~1.3 s).
 // Cleared automatically once the smoother reaches target.
 static bool     g_fastFadeUp      = false;
 
-static void enterIdleLedsOff();
-static void enterIdleLedsOn();
+// LED visibility — orthogonal to AppState. Short-press toggles g_ledsHidden;
+// a separate smoother fades g_ledScale 0↔255 over ~640 ms, multiplying the
+// baseLevel handed to ledRender() so the strip fades cleanly instead of
+// snapping. Mist is NOT affected by this flag — it follows g_currentLevel
+// (wave-modulated in RUNNING) so the diffuser keeps running at the user-set
+// level even while the visuals are blanked.
+static bool     g_ledsHidden       = false;
+static uint8_t  g_ledScale         = 255;   // smoothed: 0 (hidden) … 255 (visible)
+static uint8_t  g_ledScaleTarget   = 255;   // 0 or 255, set by short-press
+static uint32_t g_lastLedScaleMs   = 0;
+
+static void enterIdle();
 static void enterRunning();
 static void enterTransitionFromRunning();
 
@@ -93,37 +127,23 @@ static bool mistMayBeActive(AppState s) {
   return s == AppState::RUNNING || s == AppState::TRANSITION_FROM_RUNNING;
 }
 
-static void enterIdleLedsOff() {
-  if (g_state == AppState::IDLE_LEDS_OFF) return;
-  const bool leavingMist = mistMayBeActive(g_state);
-  g_state = AppState::IDLE_LEDS_OFF;
-  g_targetLevel = 0;
-  g_fastFadeUp = false;
-  // Force a snap to BREATH so the next IDLE_LEDS_ON entry doesn't trigger a
-  // BREATH-to-BREATH "crossfade" (no-op anyway). Strip is dark at baseLevel=0
-  // so mode is invisible during this state.
-  ledSetMode(LedMode::BREATH);
-  if (leavingMist) mistEnable(false);      // hard-stop + inhibit
-  Serial.println("[APP] -> IDLE_LEDS_OFF");
-}
-
-static void enterIdleLedsOn() {
+static void enterIdle() {
   // Special wiring: when called from TRANSITION_FROM_RUNNING, the breath
   // restore uses a faster smoother step — capture that BEFORE the
   // idempotency check so the flag flips even if we somehow call it twice
   // in the same frame.
   const bool fromTransition = (g_state == AppState::TRANSITION_FROM_RUNNING);
-  if (g_state == AppState::IDLE_LEDS_ON) return;
+  if (g_state == AppState::IDLE) return;
   const bool leavingMist = mistMayBeActive(g_state);
-  g_state = AppState::IDLE_LEDS_ON;
+  g_state = AppState::IDLE;
   g_targetLevel = g_userLevel;
   g_fastFadeUp = fromTransition;
   // BREATH triggers the WAVE→BREATH crossfade in led_driver when coming
-  // from RUNNING / TRANSITION; from IDLE_LEDS_OFF it's a no-op (already
-  // BREATH). led_driver collapses no-op mode changes for us.
+  // from RUNNING / TRANSITION. led_driver collapses no-op mode changes
+  // for us if we were already BREATH (e.g. boot).
   ledSetMode(LedMode::BREATH);
   if (leavingMist) mistEnable(false);
-  Serial.println("[APP] -> IDLE_LEDS_ON");
+  Serial.println("[APP] -> IDLE");
 }
 
 static void enterRunning() {
@@ -148,11 +168,43 @@ static void enterTransitionFromRunning() {
   g_targetLevel = 0;
   // Mode STAYS as WAVE — the wave naturally dims to black as baseLevel
   // ramps 255→0 (it scales the whole render uniformly). When the smoother
-  // lands at 0 it auto-enters IDLE_LEDS_ON which kicks off the WAVE→BREATH
+  // lands at 0 it auto-enters IDLE which kicks off the WAVE→BREATH
   // crossfade for the restore.
   g_fastFadeUp = false;
   mistEnable(false);                       // hard-stop + inhibit
   Serial.println("[APP] -> TRANSITION_FROM_RUNNING");
+}
+
+// ----------------------------------------------------------------------
+// Wave-modulated mist level — only meaningful in RUNNING (mist is inhibited
+// in every other state, so the value is don't-care there).
+//
+// factor (Q8) = MIST_WAVE_TROUGH_Q8 + ((256 - MIST_WAVE_TROUGH_Q8) * gauss) >> 8
+// mist_level  = (g_currentLevel * factor) >> 8
+//
+// gauss = waveIntensityAtPiezo(now) — the wave's gaussian sampled at the
+// piezo position (1 LED above the top), so the mist crest follows the
+// wave crest *across the top of the strip*, not at any visible LED.
+// ----------------------------------------------------------------------
+static uint8_t computeMistOutLevel(uint32_t now) {
+  if (g_currentLevel == 0) return 0;
+  const uint16_t gauss = uint16_t(waveIntensityAtPiezo(now));
+  const uint16_t span  = 256u - MIST_WAVE_TROUGH_Q8;
+  const uint16_t factor = MIST_WAVE_TROUGH_Q8 + ((span * gauss) >> 8);
+  return uint8_t((uint16_t(g_currentLevel) * factor) >> 8);
+}
+
+// ----------------------------------------------------------------------
+// LED visibility helpers — short-press flips g_ledsHidden and retargets the
+// scaler. Long-press / state changes never touch this; it's strictly user-
+// driven via the button.
+// ----------------------------------------------------------------------
+static void setLedsHidden(bool hidden) {
+  if (g_ledsHidden == hidden) return;
+  g_ledsHidden = hidden;
+  g_ledScaleTarget = hidden ? 0 : 255;
+  Serial.print("[APP] LEDs ");
+  Serial.println(hidden ? "hidden (mist continues at set level)" : "visible");
 }
 
 // ----------------------------------------------------------------------
@@ -163,7 +215,7 @@ static void enterTransitionFromRunning() {
 // used to make the post-removal breath restore feel brisk).
 //
 // One state-machine side effect fires here: when the smoother lands on 0
-// while in TRANSITION_FROM_RUNNING, auto-enter IDLE_LEDS_ON to kick off the
+// while in TRANSITION_FROM_RUNNING, auto-enter IDLE to kick off the
 // WAVE→BREATH crossfade as the breath fades back in. The RUNNING-side
 // "fade up then engage swirl" two-step from the prior design is gone —
 // led_driver crossfades BREATH↔WAVE directly the moment ledSetMode is
@@ -188,13 +240,36 @@ static void smoothLevel() {
   // Landed on target.
   g_fastFadeUp = false;
   if (g_state == AppState::TRANSITION_FROM_RUNNING && g_targetLevel == 0) {
-    enterIdleLedsOn();                     // kicks off WAVE→BREATH crossfade
+    enterIdle();                           // kicks off WAVE→BREATH crossfade
   }
 }
 
 // ----------------------------------------------------------------------
-// Long-press level ramp: while held, adjust g_userLevel (and the target if
-// we're in a state that follows user level). Direction inverts on release.
+// LED visibility scaler smoother — independent of the level smoother. Eases
+// g_ledScale toward g_ledScaleTarget (0 or 255) over ~640 ms so the strip
+// fades cleanly when the short-press toggles g_ledsHidden. Mist is NOT
+// gated by this scaler.
+// ----------------------------------------------------------------------
+static void smoothLedScale() {
+  const uint32_t now = millis();
+  if (now - g_lastLedScaleMs < LEVEL_SMOOTH_TICK_MS) return;
+  g_lastLedScaleMs = now;
+
+  if (g_ledScale < g_ledScaleTarget) {
+    const uint8_t room = g_ledScaleTarget - g_ledScale;
+    g_ledScale += (room < LED_SCALE_STEP_PER_TICK) ? room : LED_SCALE_STEP_PER_TICK;
+  } else if (g_ledScale > g_ledScaleTarget) {
+    const uint8_t room = g_ledScale - g_ledScaleTarget;
+    g_ledScale -= (room < LED_SCALE_STEP_PER_TICK) ? room : LED_SCALE_STEP_PER_TICK;
+  }
+}
+
+// ----------------------------------------------------------------------
+// Long-press level ramp: while held, adjust g_userLevel (and the target,
+// since IDLE and RUNNING both follow user level live). Direction inverts
+// on release. The ramp clamps at 0/255; there's no auto-snap-to-off
+// anymore — turning the device "off" is a separate gesture (short-press
+// hides the LEDs, lifting the container hard-stops the mist).
 // ----------------------------------------------------------------------
 static void rampUserLevel() {
   const uint32_t now = millis();
@@ -206,21 +281,7 @@ static void rampUserLevel() {
   if (v > 255) v = 255;
   g_userLevel = uint8_t(v);
 
-  // RUNNING and IDLE_LEDS_ON both follow the user level live. IDLE_LEDS_OFF
-  // doesn't react to long-press, so we wouldn't be here in that state.
   g_targetLevel = g_userLevel;
-
-  // Dim-to-zero snap: drop into IDLE_LEDS_OFF and reset g_userLevel to the
-  // default so a subsequent short-press into RUNNING / IDLE_LEDS_ON wakes at
-  // a visible level (otherwise it would come up at 0 and look broken).
-  // We set g_dimDir = +1 here so the LongPressEnd flip on release lands at
-  // -1, which is the correct direction for the natural next gesture: "I'm
-  // back at full level, long-press to dim again."
-  if (g_dimDir < 0 && g_userLevel <= LEVEL_OFF_THRESHOLD) {
-    g_userLevel = LEVEL_DEFAULT;
-    g_dimDir = +1;
-    enterIdleLedsOff();
-  }
 }
 
 // ----------------------------------------------------------------------
@@ -229,7 +290,7 @@ static void rampUserLevel() {
 static void printHelp() {
   Serial.println(F("[CMD] commands:"));
   Serial.println(F("  help          - print this list"));
-  Serial.println(F("  1 / 0 / t     - mist on / off / toggle (requires container)"));
+  Serial.println(F("  l / L / t     - hide LEDs / show LEDs / toggle (mist unaffected)"));
   Serial.println(F("  vN            - set user level (mist + LED level), 0..255"));
   Serial.println(F("  w             - run ledWalk (~14 s, blocks)"));
   Serial.println(F("  k             - recalibrate baseline (Phase B)"));
@@ -258,31 +319,21 @@ static void handleCommand(const char* cmd, uint8_t len) {
 
   const char c = cmd[0];
   switch (c) {
-    case '1':
-      if (containerIsPresent()) enterRunning();
-      else Serial.println("[CMD] container not present — use button to toggle LEDs");
-      return;
-    case '0': enterIdleLedsOff(); return;
+    case 'l': setLedsHidden(true);  return;
+    case 'L': setLedsHidden(false); return;
     case 't':
-      // Mirror the short-press button: mute if active, wake if muted. From a
-      // muted state, dock state decides whether we wake into RUNNING or just
-      // the ambient breath.
-      if (g_state == AppState::IDLE_LEDS_OFF) {
-        if (containerIsPresent()) enterRunning();
-        else                      enterIdleLedsOn();
-      } else {
-        enterIdleLedsOff();
-      }
+      // Mirror the short-press button: just toggle LED visibility. Mist
+      // behaviour is unchanged — keeps running at g_userLevel whenever a
+      // container is docked, regardless of LED visibility.
+      setLedsHidden(!g_ledsHidden);
       return;
     case 'v': {
       const long v = parseTail(cmd, len);
       if (v < 0 || v > 255) { Serial.println("[CMD] v: 0..255"); return; }
       g_userLevel = uint8_t(v);
-      // Apply live ONLY in the steady-state active states. IDLE_LEDS_OFF is
-      // muted; TRANSITION_FROM_RUNNING is fading to 0 and overriding target
-      // would interrupt the cinematic.
-      const bool applyNow =
-          g_state == AppState::RUNNING || g_state == AppState::IDLE_LEDS_ON;
+      // IDLE and RUNNING both follow user level live; TRANSITION_FROM_RUNNING
+      // is fading to 0 and overriding target would interrupt the cinematic.
+      const bool applyNow = g_state != AppState::TRANSITION_FROM_RUNNING;
       if (applyNow) {
         g_targetLevel = g_userLevel;
         Serial.print("[APP] user level=");
@@ -290,7 +341,7 @@ static void handleCommand(const char* cmd, uint8_t len) {
       } else {
         Serial.print("[APP] user level=");
         Serial.print(v);
-        Serial.println(" (stored; applies on next wake)");
+        Serial.println(" (stored; applies after lift-cinematic)");
       }
       return;
     }
@@ -351,25 +402,22 @@ static void onContainerEvent(ContainerEvent ev) {
 static void onButtonEvent(ButtonEvent ev) {
   switch (ev) {
     case ButtonEvent::ShortPress:
-      // Short-press is "mute toggle / wake from mute". It cuts straight to
-      // IDLE_LEDS_OFF from any active state — including TRANSITION_FROM_
-      // RUNNING (the user explicitly asked to skip the cinematic).
-      if (g_state == AppState::IDLE_LEDS_OFF) {
-        if (containerIsPresent()) enterRunning();
-        else                      enterIdleLedsOn();
-      } else {
-        enterIdleLedsOff();
-      }
+      // Short-press toggles ONLY the LED strip visibility (smoothly faded
+      // by g_ledScale). Mist stays at the user's set level — if a container
+      // is docked, the diffuser keeps running while the visuals go dark.
+      setLedsHidden(!g_ledsHidden);
       return;
     case ButtonEvent::LongPressStart:
-      if (g_state == AppState::RUNNING || g_state == AppState::IDLE_LEDS_ON) {
+      // Long-press ramps the user level in IDLE / RUNNING; the cinematic
+      // dim of TRANSITION_FROM_RUNNING is left alone.
+      if (g_state != AppState::TRANSITION_FROM_RUNNING) {
         g_lastRampMs = millis();
         Serial.print("[BTN] long-press start, dir=");
         Serial.println(int(g_dimDir));
       }
       return;
     case ButtonEvent::LongPressTick:
-      if (g_state == AppState::RUNNING || g_state == AppState::IDLE_LEDS_ON) {
+      if (g_state != AppState::TRANSITION_FROM_RUNNING) {
         rampUserLevel();
       }
       return;
@@ -387,8 +435,7 @@ static void onButtonEvent(ButtonEvent ev) {
 // ----------------------------------------------------------------------
 static const char* stateName(AppState s) {
   switch (s) {
-    case AppState::IDLE_LEDS_OFF:           return "IDLE_OFF";
-    case AppState::IDLE_LEDS_ON:            return "IDLE_ON";
+    case AppState::IDLE:                    return "IDLE";
     case AppState::RUNNING:                 return "RUNNING";
     case AppState::TRANSITION_FROM_RUNNING: return "XFADE_OUT";
   }
@@ -400,6 +447,7 @@ static void statTick() {
   if (now - g_lastStatMs < 1000) return;
   g_lastStatMs = now;
   Serial.print("[STAT] state=");       Serial.print(stateName(g_state));
+  Serial.print(" leds=");              Serial.print(g_ledsHidden ? "hidden" : "visible");
   Serial.print(" reed=");              Serial.print(containerRawPresent() ? 1 : 0);
   Serial.print(" btn=");               Serial.print(digitalRead(PIN_BUTTON));
   Serial.print(" user=");              Serial.print(g_userLevel);
@@ -437,30 +485,39 @@ void setup() {
   containerInit();
   buttonInit();
 
-  // Boot lands in IDLE_LEDS_ON (default soft breath). If a container is
-  // already docked at power-on, the first containerPoll() will edge-trigger
+  // Boot lands in IDLE (default soft breath). If a container is already
+  // docked at power-on, the first containerPoll() will edge-trigger
   // Inserted after the 500 ms safety dwell and we'll head into RUNNING.
   //
-  // The static initializer above already sets g_state = IDLE_LEDS_ON so the
-  // idempotent enterIdleLedsOn() is a no-op; we set target + LED mode here
+  // The static initializer above already sets g_state = IDLE so the
+  // idempotent enterIdle() is a no-op; we set target + LED mode here
   // explicitly so neither depends on the leaf modules' init order, and we
   // print the resolved state to make the boot log unambiguous.
   g_targetLevel = g_userLevel;
   ledSetMode(LedMode::BREATH);
-  Serial.println("[APP] state=IDLE_LEDS_ON (boot)");
+  Serial.println("[APP] state=IDLE (boot, LEDs visible)");
   printHelp();
 }
 
 void loop() {
+  const uint32_t now = millis();
   pollSerial();
 
   // Subsystem ticks
   currentSenseTick();
   smoothLevel();
+  smoothLedScale();
 
-  // Apply smoothed level to outputs
-  mistApply(g_currentLevel);
-  ledRender(g_currentLevel);
+  // Apply smoothed level to outputs.
+  //
+  // Mist: wave-modulated at the piezo position (only meaningful in RUNNING;
+  // mist is inhibited everywhere else, so mistApply is a no-op there).
+  // LEDs: scaled by g_ledScale (the short-press hide/show fade) so the
+  // strip can be blanked without touching mist.
+  mistApply(computeMistOutLevel(now));
+  const uint8_t ledBase =
+      uint8_t((uint16_t(g_currentLevel) * uint16_t(g_ledScale)) >> 8);
+  ledRender(ledBase);
 
   // Input edges + diagnostics
   onContainerEvent(containerPoll());

--- a/variants/block-kit/firmware/BlockKit_Test/README.md
+++ b/variants/block-kit/firmware/BlockKit_Test/README.md
@@ -2,41 +2,51 @@
 
 Block Kit V0.1 firmware that exercises every subsystem (mist PWM, reed switch, button, IS31FL3731 LED ring, D7 indicator LED) **plus** a "scope mode" that streams the INA180 current data so the water-detection algorithm can be designed from real bench data later (Phase B).
 
-Phase A intentionally has **no water-level classifier**. The reed switch is the primary on-gesture (magnetic-on); the button toggles state and ramps level. One unified "level" variable drives both mist PWM duty and LED ring brightness — they always move together.
+Phase A intentionally has **no water-level classifier**. The reed switch is the primary on-gesture (magnetic-on); the button short-press hides the LED strip without touching the mist; long-press ramps the level. One unified `g_userLevel` variable drives both mist PWM duty and LED ring brightness so they move together; while `RUNNING`, the mist drive is additionally modulated by the wave swell at the piezo position so the mist visibly pulses with the LED animation.
 
 ## States
 
-Four top-level states, all transitions handled in `BlockKit_Test.ino::loop()`. A level smoother fades `g_currentLevel` toward whatever the new state's target is in tiny per-tick steps (+2 / 10 ms ≈ 1.3 s 0→255), so every brightness change reads as a continuous slide. The LED driver runs an automatic 1.1 s **crossfade** whenever the mode swaps between BREATH and WAVE — there is never a snap.
+Three container-driven states, all transitions handled in `BlockKit_Test.ino::loop()`. A level smoother fades `g_currentLevel` toward whatever the new state's target is in tiny per-tick steps (+2 / 10 ms ≈ 1.3 s 0→255), so every brightness change reads as a continuous slide. The LED driver runs an automatic 1.1 s **crossfade** whenever the mode swaps between BREATH and WAVE — there is never a snap.
 
-| State                     | When                              | Mist         | LED ring                                          | D7 white    |
-|---------------------------|-----------------------------------|--------------|---------------------------------------------------|-------------|
-| `IDLE_LEDS_OFF`           | No container, muted               | off          | dark                                              | dim (~10 %) |
-| `IDLE_LEDS_ON` *(default)*| No container, awake (boot lands here) | off       | deep-dim exp(sin) BREATH; exhale dwells at black  | dim (~10 %) |
-| `RUNNING`                 | Container docked                  | PWM at level | WAVE — every LED always lit, single slow gaussian swell rising bottom→top over 7.5 s | off |
-| `TRANSITION_FROM_RUNNING` | Container just lifted             | hard-stopped | Wave dims to 0 (~0.85 s), then auto-enters `IDLE_LEDS_ON` for the BREATH crossfade | dim (~10 %) |
+LED visibility is **orthogonal** to state: a separate boolean (`g_ledsHidden`, toggled by the short-press button) hides or shows the strip with its own ~640 ms fade. Mist is unaffected by this flag — short-pressing only mutes the visuals; it never stops the diffuser.
+
+| State                     | When                              | Mist                                              | LED ring                                          | D7 white    |
+|---------------------------|-----------------------------------|---------------------------------------------------|---------------------------------------------------|-------------|
+| `IDLE` *(default boot)*   | No container                      | off                                               | deep-dim exp(sin) BREATH; exhale dwells at black  | dim (~10 %) |
+| `RUNNING`                 | Container docked                  | **Wave-modulated** at piezo position — mist pulses with the LED swell; trough ≈ 36 % of set level | WAVE — every LED always lit, single slow gaussian swell rising bottom→top over 7.5 s | off |
+| `TRANSITION_FROM_RUNNING` | Container just lifted             | hard-stopped                                      | Wave dims to 0 (~0.85 s), then auto-enters `IDLE` for the BREATH crossfade | dim (~10 %) |
 
 ### Transition map
 
 | From state                  | Event                              | To state                  | Notes                                                                                  |
 |-----------------------------|------------------------------------|---------------------------|----------------------------------------------------------------------------------------|
-| `IDLE_LEDS_OFF`             | Container inserted (reed 500 ms)   | `RUNNING`                 | Mist + LEDs ramp up; BREATH→WAVE crossfade (1.1 s)                                     |
-| `IDLE_LEDS_OFF`             | Button short-press (no container)  | `IDLE_LEDS_ON`            | Deep-dim BREATH fades in (~1.3 s)                                                      |
-| `IDLE_LEDS_ON`              | Container inserted (reed 500 ms)   | `RUNNING`                 | BREATH→WAVE crossfade — dim breath dissolves into slow swell                           |
-| `IDLE_LEDS_ON`              | Button short-press                 | `IDLE_LEDS_OFF`           | Breath fades out                                                                       |
+| `IDLE`                      | Container inserted (reed 500 ms)   | `RUNNING`                 | BREATH→WAVE crossfade — dim breath dissolves into slow swell                           |
 | `RUNNING`                   | Container removed (reed 100 ms)    | `TRANSITION_FROM_RUNNING` | **Mist hard-stops** (safety); wave dims naturally as baseLevel ramps 255→0             |
-| `RUNNING`                   | Button short-press                 | `IDLE_LEDS_OFF`           | Mist hard-stops; LEDs fade out (skips cinematic)                                       |
-| `TRANSITION_FROM_RUNNING`   | Smoother lands at 0                | `IDLE_LEDS_ON`            | Mode→BREATH (WAVE→BREATH crossfade); fast restore (~0.64 s)                            |
+| `TRANSITION_FROM_RUNNING`   | Smoother lands at 0                | `IDLE`                    | Mode→BREATH (WAVE→BREATH crossfade); fast restore (~0.64 s)                            |
 | `TRANSITION_FROM_RUNNING`   | Container re-inserted              | `RUNNING`                 | Crossfade engine takes over mid-fade — clean recovery, no special case                 |
-| `RUNNING` or `IDLE_LEDS_ON` | Button long-press                  | (no transition)           | Ramps `g_userLevel`; mist + LED brightness follow live (wave traverse rate unchanged)  |
-| any state where level dims past 8 | (auto)                       | `IDLE_LEDS_OFF`           | Avoids "stuck dim" — user can re-engage                                                |
+| any state                   | Button **short-press**             | (no state change)         | Toggles `g_ledsHidden`. LED render fades to/from 0 over ~640 ms. Mist unchanged.       |
+| `IDLE` or `RUNNING`         | Button **long-press**              | (no state change)         | Ramps `g_userLevel`; mist + LED brightness follow live (wave traverse rate unchanged)  |
 
-### One level to rule them all
+### One level + an orthogonal hide flag
 
 `g_userLevel` (0..255) is the user-set "intensity". It controls:
-- **Mist PWM duty** = `(level × MIST_DUTY_MAX) / 255` — level 255 ⇒ 50 % duty (full mist).
+- **Mist PWM duty** = `(level × MIST_DUTY_MAX) / 255` — level 255 ⇒ 50 % duty (full mist). In `RUNNING` the duty is *further* modulated by the wave swell at the piezo position — see "Wave-mist sync" below.
 - **LED ring brightness** — scales the entire render (BREATH cap and WAVE base+swell) uniformly.
 
-`g_targetLevel` is what the current state wants the level to be (0 for IDLE_LEDS_OFF / TRANSITION_FROM_RUNNING, `g_userLevel` otherwise). `g_currentLevel` is smoothed toward target each tick in deliberately tiny steps so the fade reads as continuous, not stepped. Both mist and LEDs move together.
+`g_targetLevel` is what the current state wants the level to be (0 in `TRANSITION_FROM_RUNNING`, `g_userLevel` otherwise). `g_currentLevel` is smoothed toward target each tick in deliberately tiny steps so the fade reads as continuous, not stepped.
+
+`g_ledsHidden` is the short-press toggle. When set, a per-LED scaler (`g_ledScale`, 0..255 smoothed over ~640 ms) multiplies the `g_currentLevel` handed to `ledRender()`. Mist does NOT see this scaler — so blanking the visuals never stops the diffuser. Long-press to adjust the level still works whether the LEDs are hidden or not (you'll feel the change through the mist).
+
+### Wave-mist sync (RUNNING only)
+
+While `RUNNING`, mist drive is no longer a flat `g_currentLevel`. Each tick the firmware samples the wave's gaussian swell at the **piezo position** (1 LED above index 0, where the piezo disc physically sits) and uses it to modulate the mist:
+
+```
+factor (Q8) = MIST_WAVE_TROUGH_Q8 + ((256 - MIST_WAVE_TROUGH_Q8) × gauss_at_piezo) / 256
+mist_level  = (g_currentLevel × factor) / 256
+```
+
+Because the piezo sits *above* the top LED, the gaussian peaks at the piezo **after** the wave has visibly crossed the top of the strip — so the mist "continues to grow" as the swell passes the top, then dims back down together with the top LED as the wave exits off-screen above. At max user level (255) the mist swings between ~36 % and 100 % of full duty — visible pulse, but proportional to the wave's own 92/255 trough-to-peak ratio so the LEDs you see and the mist you feel feel like one motion.
 
 ### Lift-off is a SAFETY event
 
@@ -74,12 +84,12 @@ On boot you'll see the banner, the resolved pin map, and the command list. Every
 [APP] Block Kit V0.1 bring-up (Phase A)
 [APP] PIN_MIST_PWM=D0 (GPIO 0)
 [APP] PIN_REED=D10 (GPIO 18)
-[APP] -> IDLE_LEDS_OFF
+[APP] state=IDLE (boot, LEDs visible)
 [REED] inserted
 [APP] -> RUNNING
 [MIST] on (boost up)
-[STAT] state=RUNNING reed=1 btn=0 user=255 cur=140 mist=1 mean_mA=178.2
-[PLOT] 178.4,12.3,2
+[STAT] state=RUNNING leds=visible reed=1 btn=0 user=255 cur=140 mist=1 mean_mA=178.2
+[PLOT] 178.4,12.3,1
 [BTN] long-press start, dir=-1
 ```
 
@@ -92,7 +102,7 @@ On boot you'll see the banner, the resolved pin map, and the command list. Every
 | Cmd | Effect |
 |---|---|
 | `help` | Print this list |
-| `1` / `0` / `t` | Mist on / off / toggle (requires container for on) |
+| `l` / `L` / `t` | Hide LEDs / show LEDs / toggle visibility (mist is unaffected) |
 | `vN` | Set `g_userLevel` directly, 0..255 (e.g. `v180`) |
 | `w` | Run `ledWalk` (lights LEDs 0..13 in sequence — blocks ~14 s) |
 | `k` | (Phase B placeholder) recalibrate current-sense baseline |
@@ -107,10 +117,10 @@ The LED driver addresses Matrix B of the IS31FL3731 directly via `setLEDPWM(ledn
 1. **Boot output:** confirm `[APP] PIN_*=… (GPIO N)` lines match the XIAO ESP32-C6 expected values (D0=0, D10=18, D2=2, D3=21, D6=16, D7=17). If they don't, the board selected in Tools→Board is wrong.
 2. **Walk:** send `w` → 14 LEDs light in sequence with `[LED] walk i=N lednum=M`. If the physical order differs from top→bottom, reorder `LED_MAP[]` in `pins.h`.
 3. **D7 indicator:** at boot with no container, D7 should be dim and steady.
-4. **LEDs ambient toggle:** press the button briefly with no container → ring fades in to user level. Press again → fades out.
-5. **Mist trigger:** dock a container with a magnet → after the 500 ms dwell, `[APP] -> RUNNING`, D3 goes HIGH (red LED2 lights), mist + ring ramp up together over ~800 ms.
+4. **Short-press hides LEDs only:** press the button briefly (with or without a container) → `[APP] LEDs hidden …`, the strip fades to dark over ~640 ms. Mist (if a container is docked) keeps running at the same level. Press again → `[APP] LEDs visible`, strip fades back in.
+5. **Mist trigger + wave-sync:** dock a container with a magnet → after the 500 ms dwell, `[APP] -> RUNNING`, D3 goes HIGH (red LED2 lights), mist + ring ramp up together. Once steady, the **mist visibly pulses with the swell** — the mist peaks just after the LED swell crosses the top of the strip, then dims back down together with it.
 6. **Mist shut-off:** lift the container → `[REED] removed` after 100 ms, **mist hard-stops** (no fade), ring continues fading down, D7 returns to dim.
-7. **Long-press ramp:** while RUNNING (or `IDLE_LEDS_ON`), hold the button → ring + mist dim together. Release. Hold again → ramp the other direction.
+7. **Long-press ramp:** while RUNNING (or `IDLE`), hold the button → ring + mist dim together (mist still pulses with the wave on top of the dim). Release. Hold again → ramp the other direction. The ramp clamps at 0/255; long-pressing to 0 leaves you at level 0, not in a special "off" state — the LEDs stay visible (just dark), and the next long-press in the other direction brightens back up.
 8. **Current data (Phase B prep):** with a docked container at full level, send `s` and open Serial Plotter. Capture `mean_mA, var_mA2` traces for full water, low water, dry disc, no disc.
 
 ## Files

--- a/variants/block-kit/firmware/BlockKit_Test/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Test/led_driver.ino
@@ -205,22 +205,28 @@ static void renderBreathRaw(uint32_t now, uint8_t out[LED_COUNT]) {
   for (uint8_t i = 0; i < LED_COUNT; ++i) out[i] = pwm;
 }
 
-static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
-  // The swell center travels from y = LED_COUNT + 3σ (off-screen below) to
-  // y = -3σ (off-screen above) over WAVE_PERIOD_MS, then jumps back instantly.
-  // The jump is invisible: at ±3σ from any LED the gaussian is < 1% of peak,
-  // so visually the strip just sits at WAVE_BASE_LEVEL for a tick during the
-  // wrap, then a new swell emerges smoothly from below.
-  //
-  // The strip is indexed top→bottom (i=0 top, i=13 bottom), and the user
-  // asked for the swell to rise from bottom to top. So as t advances, y
-  // decreases (head moves toward lower index = upward).
+// Position of the wave swell center in Q8 LED units. The strip is indexed
+// top→bottom (i=0 top, i=13 bottom), and the user asked for the swell to
+// rise from bottom to top — so y decreases as t advances (head moves
+// toward lower index = upward). The swell travels from y = LED_COUNT + 3σ
+// (off-screen below) to y = -3σ (off-screen above) over WAVE_PERIOD_MS,
+// then wraps. The jump is invisible: at ±3σ from any visible LED the
+// gaussian is < 1% peak, so the strip just sits at WAVE_BASE_LEVEL for a
+// tick during the wrap before a new swell emerges smoothly from below.
+//
+// Shared between renderWaveRaw and waveIntensityAtPiezo so the visible LED
+// swell and the mist modulation are guaranteed phase-locked off the same
+// `now` — the mist you feel is literally the wave you see.
+static inline int32_t waveCenterYQ8(uint32_t now) {
   const int32_t span_q8 = int32_t(LED_COUNT) * 256
                         + int32_t(WAVE_TRAVEL_PAD_Q8) * 2;
   const uint32_t t = uint32_t(now) % WAVE_PERIOD_MS;
-  const int32_t  y_q8 = int32_t(LED_COUNT) * 256 + int32_t(WAVE_TRAVEL_PAD_Q8)
-                      - int32_t((uint64_t(span_q8) * t) / WAVE_PERIOD_MS);
+  return int32_t(LED_COUNT) * 256 + int32_t(WAVE_TRAVEL_PAD_Q8)
+       - int32_t((uint64_t(span_q8) * t) / WAVE_PERIOD_MS);
+}
 
+static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
+  const int32_t y_q8 = waveCenterYQ8(now);
   for (uint8_t i = 0; i < LED_COUNT; ++i) {
     const int32_t led_q8 = int32_t(i) * 256;
     int32_t       d_q8   = led_q8 - y_q8;
@@ -233,6 +239,27 @@ static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
     if (v > 255) v = 255;
     out[i] = uint8_t(v);
   }
+}
+
+// Returns the wave gaussian intensity (0..255) at the piezo's position —
+// 1 LED above index 0 (configurable via MIST_PIEZO_OFFSET_LEDS_Q8). When
+// the swell is centered at the piezo, returns 255 (mist crest); when far
+// away, returns 0 (mist trough). The main loop multiplies this through
+// g_currentLevel + the MIST_WAVE_TROUGH_Q8 floor to produce the actual
+// mist drive level — see `computeMistOutLevel()` in BlockKit_Test.ino.
+//
+// Because the piezo is physically above the top LED, the gaussian peaks at
+// the piezo *after* the LED at index 0 has already peaked — so the mist
+// "continues to grow" once the wave has visibly passed the top, then dims
+// back down with the wave as it exits off-screen above. That timing is
+// the whole point of evaluating here instead of at index 0.
+uint8_t waveIntensityAtPiezo(uint32_t now) {
+  const int32_t y_q8     = waveCenterYQ8(now);
+  const int32_t piezo_q8 = -int32_t(MIST_PIEZO_OFFSET_LEDS_Q8);  // above i=0
+  int32_t       d_q8     = piezo_q8 - y_q8;
+  if (d_q8 < 0) d_q8 = -d_q8;
+  if (d_q8 > 0xFFFF) return 0;
+  return gaussQ(uint16_t(d_q8));
 }
 
 static inline void renderRaw(LedMode m, uint32_t now, uint8_t out[LED_COUNT]) {

--- a/variants/block-kit/firmware/BlockKit_Test/pins.h
+++ b/variants/block-kit/firmware/BlockKit_Test/pins.h
@@ -63,6 +63,28 @@ constexpr uint32_t MIST_FREQ_HZ    = 108700;  // ceramic disc resonance
 constexpr uint8_t  MIST_PWM_RES    = 8;       // 8-bit -> 0..255 duty
 constexpr uint8_t  MIST_DUTY_MAX   = 127;     // 50% duty = full mist (peak level)
 
+// ---------- Mist ↔ wave sync (RUNNING only) ----------
+//
+// While in RUNNING, mist output is no longer a flat g_currentLevel — it's
+// modulated by the wave's gaussian swell evaluated at the piezo position
+// so the mist physically pulses in sync with the LED wave. The piezo disc
+// sits ABOVE the top LED of the strip (index 0), so the modulation is
+// evaluated 1 LED above index 0: the mist peaks AFTER the wave has visibly
+// crossed the top of the strip, then dims down together with the top LED
+// as the wave continues off-screen above. From the user's POV the mist
+// "rises with the swell, peaks at the piezo, and dims with it" — the wave
+// you see and the mist you feel are one motion.
+//
+//   factor (Q8) = MIST_WAVE_TROUGH_Q8
+//               + ((256 - MIST_WAVE_TROUGH_Q8) * gauss_at_piezo) >> 8
+//   mist_level  = (g_currentLevel * factor) >> 8
+//
+// At max user level (255), mist swings between TROUGH and FULL. The trough
+// is set so the dip is *visible but proportional* — matching WAVE_BASE_LEVEL's
+// 92/255 ≈ 36 % trough-to-peak ratio so the mist's swing mirrors the LEDs'.
+constexpr uint16_t MIST_PIEZO_OFFSET_LEDS_Q8 = 256;  // piezo sits 1 LED above index 0
+constexpr uint16_t MIST_WAVE_TROUGH_Q8       = 92;   // 92/256 ≈ 36 % — matches WAVE base/peak ratio
+
 // ---------- Status LED (D7) ----------
 // Simple on-or-off "waiting" indicator. Dim PWM when no container is docked,
 // fully off when the container is on the dock.
@@ -186,10 +208,23 @@ constexpr uint8_t  LEVEL_SMOOTH_STEP_UP_FAST = 4;   // ~0.64 s 0→255
 
 // Default level on first boot — bold first impression (full mist).
 constexpr uint8_t  LEVEL_DEFAULT         = 255;
-// Long-press ramp step + auto-off threshold.
+// Long-press ramp step. The minimum reachable level is 0 — there is no
+// auto-snap-to-off; the user holds until satisfied. Direction flips on
+// release. (The short-press toggle hides only the LEDs and leaves mist
+// running at the user's set level — see g_ledsHidden below.)
 constexpr uint16_t LEVEL_RAMP_TICK_MS    = 13;      // ~77 steps/sec while held
 constexpr uint8_t  LEVEL_RAMP_STEP       = 1;
-constexpr uint8_t  LEVEL_OFF_THRESHOLD   = 8;       // dimming below this snaps to OFF state
+
+// ---------- LED visibility scaler (short-press hide/show) ----------
+//
+// Short-press toggles `g_ledsHidden` — an orthogonal boolean that hides the
+// LED strip *without* touching mist. A separate smoother fades a per-LED
+// scale factor (0..255) between 0 (hidden) and 255 (visible) over ~640 ms
+// so the LEDs ease out instead of snapping. Mist continues to follow
+// g_currentLevel (wave-modulated in RUNNING) independent of this flag — so
+// you can "blank the visuals while keeping the diffuser running at the
+// level you set with long-press".
+constexpr uint8_t  LED_SCALE_STEP_PER_TICK = 4;     // ~640 ms 0→255 hide/show fade
 
 // ---------- Serial ----------
 constexpr uint32_t SERIAL_BAUD          = 115200;
@@ -197,41 +232,48 @@ constexpr uint32_t PLOT_PRINT_HZ        = 20;       // [PLOT] CSV rate when scop
 
 // ---------- Top-level state machine ----------
 //
-//   Boot lands in IDLE_LEDS_ON (soft breath waiting). Short-press toggles to
-//   IDLE_LEDS_OFF and back. Container docking always wins: any state +
+//   The state machine tracks ONLY container/event flow — three states.
+//   Whether the LED strip is rendered or hidden is an *orthogonal* boolean
+//   (`g_ledsHidden`) toggled by the short-press button, so muting the
+//   visuals never interrupts misting. Boot lands in IDLE with LEDs visible
+//   (soft breath waiting). Container docking always wins: any state +
 //   container → RUNNING. Container removal in RUNNING goes through a brief
-//   TRANSITION_FROM_RUNNING (wave decelerates + dims to 0, then breath fades
-//   back in) before landing back in IDLE_LEDS_ON.
+//   TRANSITION_FROM_RUNNING (wave decelerates + dims to 0, then breath
+//   fades back in) before landing back in IDLE.
 //
 //   The BREATH ↔ WAVE swap on dock/undock is always a CROSSFADE (mixed in
 //   pre-gamma space by led_driver), not a snap. So when you dock a container
 //   in idle, the dim breath dissolves smoothly into a slow swelling wave —
 //   reads as one continuous gesture, not "fade up then start chasing".
 //
-//   ┌─────────────────┐   short-press   ┌─────────────────────────────┐
-//   │ IDLE_LEDS_OFF   │ ──────────────► │ IDLE_LEDS_ON  (default boot) │
-//   │ ring dark, D7 ▒│ ◄────────────── │ deep dim breath, D7 ▒        │
-//   └────────┬────────┘   short-press   └─────────────┬───────────────┘
-//            │                                        │
-//       container ↓                              container ↓
-//            ▼                                        ▼ (BREATH→WAVE crossfade)
-//                ┌────────────────────────────────────────────┐
-//                │  RUNNING                                   │
-//                │  soft gaussian swell traveling bottom→top │
-//                │  mist on, D7 off, every LED always lit    │
-//                └─────────────────┬──────────────────────────┘
+//                ┌──────────────────────────────────────────────┐
+//                │  IDLE  (default boot, LEDs visible)          │
+//                │  deep dim BREATH, mist off, D7 ▒             │
+//                └─────────────────┬────────────────────────────┘
+//                                  │ container docked
+//                                  ▼ (BREATH→WAVE crossfade, 1.1 s)
+//                ┌──────────────────────────────────────────────┐
+//                │  RUNNING                                     │
+//                │  WAVE: soft gaussian swell, bottom → top     │
+//                │  mist on, wave-modulated at piezo position   │
+//                │  D7 off, every LED always lit                │
+//                └─────────────────┬────────────────────────────┘
 //                                  │ container removed
 //                                  ▼ (mist hard-stops; wave dims to 0)
-//                ┌────────────────────────────────────────────┐
-//                │  TRANSITION_FROM_RUNNING                   │
-//                │  level fades 255→0 with wave still         │
-//                │  rendering, then auto-enters IDLE_LEDS_ON  │
-//                │  → WAVE→BREATH crossfade as level rises    │
-//                └────────────────────────────────────────────┘
-//   Short-press from RUNNING / TRANSITION → IDLE_LEDS_OFF (skips cinematic).
+//                ┌──────────────────────────────────────────────┐
+//                │  TRANSITION_FROM_RUNNING                     │
+//                │  level fades 255→0 with wave still rendering │
+//                │  then auto-enters IDLE → WAVE→BREATH         │
+//                │  crossfade as level rises                    │
+//                └──────────────────────────────────────────────┘
+//
+//   Orthogonal: short-press toggles `g_ledsHidden` in ANY state. Hidden →
+//   the LED render is fade-scaled to 0 over ~640 ms (mode + animation
+//   continue underneath); mist is untouched and keeps running at the user-
+//   set level if a container is docked. Long-press dims `g_userLevel` —
+//   mist and LED brightness scale together exactly as before.
 enum class AppState : uint8_t {
-  IDLE_LEDS_OFF,
-  IDLE_LEDS_ON,
+  IDLE,
   RUNNING,
   TRANSITION_FROM_RUNNING,
 };


### PR DESCRIPTION
## Summary

Two related changes to the Block Kit bring-up firmware, both keeping the LED animation itself unchanged.

### 1. Mist breathes with the wave

While in `RUNNING`, the mist drive is no longer a flat `g_currentLevel` — it's modulated by the wave swell's gaussian intensity sampled at the **piezo's position** (1 LED above the top of the strip). The piezo physically sits above the top LED, so:

- The mist rises as the swell rises up the strip.
- It peaks **after** the wave has visibly crossed the top LED (because that's when the wave reaches the piezo).
- It dims back down together with the top LED as the wave continues off-screen above — linear with the LEDs, exactly as requested.

At max user level (255) the mist swings between ~36 % and 100 % of full duty. The trough factor (`MIST_WAVE_TROUGH_Q8 = 92`) matches `WAVE_BASE_LEVEL / 255 = 92 / 255 ≈ 36 %` so the mist's swing is *proportional to the wave's own trough-to-peak ratio* — the LEDs you see and the mist you feel move as one motion.

`waveCenterYQ8()` is shared between the visible renderer and the new `waveIntensityAtPiezo()` helper so the two are guaranteed phase-locked off the same `now`. Sigma is unchanged, so the wave animation itself is untouched.

### 2. Short-press hides LEDs only; mist preserved

Short-press no longer mutes the whole device — it toggles a new orthogonal `g_ledsHidden` flag. A separate smoother fades a per-LED visibility scaler over ~640 ms (multiplied into the `baseLevel` handed to `ledRender`), but the mist path ignores the scaler, so blanking the visuals never stops the diffuser.

Long-press still ramps `g_userLevel` exactly as before — mist + LED brightness scale together. The old `IDLE_LEDS_OFF` state and the dim-past-threshold auto-snap are removed; `AppState` is now just `IDLE` / `RUNNING` / `TRANSITION_FROM_RUNNING`. The cinematic container-lift transition and the BREATH↔WAVE crossfade are unchanged.

Serial commands updated: `l` / `L` / `t` for hide / show / toggle (replacing the prior `1` / `0` / `t` mist on/off/toggle).

### Files

- `pins.h` — new `MIST_PIEZO_OFFSET_LEDS_Q8`, `MIST_WAVE_TROUGH_Q8`, `LED_SCALE_STEP_PER_TICK` tunables; `AppState` reduced from 4 to 3 states; state-machine ASCII diagram re-flowed.
- `led_driver.ino` — extracted `waveCenterYQ8()` as a shared helper; new `waveIntensityAtPiezo(now)` exposed for the main loop.
- `BlockKit_Test.ino` — `enterIdle()` replaces `enterIdleLedsOn`; `enterIdleLedsOff` removed; new `setLedsHidden`, `smoothLedScale`, `computeMistOutLevel` helpers; main loop applies wave-modulated mist + LED-scale multiplier; `[STAT]` line now reports `leds=visible|hidden`.
- `README.md`, `ARCHITECTURE.md` — state machine table, transition map, level-model section, bring-up checklist, serial command list all re-flowed to the new model.

## Test plan

- [ ] Build for `XIAO_ESP32C6` in Arduino IDE 2.x with the `Dav1dyang/Adafruit_IS31FL3731` fork installed.
- [ ] Boot with no container — log shows `[APP] state=IDLE (boot, LEDs visible)`, strip runs the deep-dim BREATH, D7 dim.
- [ ] Short-press with no container — `[APP] LEDs hidden …`, strip fades to dark over ~640 ms. Press again — `[APP] LEDs visible`, strip fades back in.
- [ ] Dock a container — `[APP] -> RUNNING`, BREATH→WAVE crossfade plays. Once steady, observe that the **mist visibly pulses with the swell** — the mist peak occurs just after the LED swell has crossed the top of the strip.
- [ ] While docked, short-press — LED strip fades dark, **mist keeps running and pulsing**. Short-press again — strip fades back in.
- [ ] Long-press while running — `g_userLevel` ramps; both the average mist level and the LED brightness scale together. Mist still pulses with the wave on top of the dim. Release → direction flips. Hold to 0 → device sits at level 0 (no mist, dark strip); next long-press in the other direction recovers normally.
- [ ] Lift container — `[REED] removed`, mist hard-stops instantly, wave dims to black, breath fades back in. D7 returns to dim.
- [ ] Re-dock during the lift cinematic — `[APP] -> RUNNING` cleanly resumes.

Hardware verification (LED brightness, wave timing, mist pulse timing) is what really matters for this change — the type-checker can't catch a "mist peaks at the wrong moment" bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxDTWoASxHcEQqSXW8nAb7)_