### PR TITLE
Fix Block Kit Production firmware compile errors (CfgBlob, HEX, macro shadow, stateName collision, mbedtls)

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/config.h
+++ b/variants/block-kit/firmware/BlockKit_Production/config.h
@@ -60,6 +60,40 @@ struct Config {
 
 extern Config cfg;
 
+// Persisted byte-layout for the tunables blob in NVS. Lives in the header so
+// the Arduino IDE's auto-generated forward declarations in config.ino can see
+// it — putting the struct definition in the .ino broke compilation because
+// the IDE inserts prototypes BEFORE the struct, and the prototypes referenced
+// CfgBlob. Plain POD, no padding surprises because every field is byte/u16-
+// aligned and the secrets (C-strings) live in separate NVS keys.
+struct CfgBlob {
+  uint8_t  version;
+  uint8_t  ledBreathPeak;
+  uint16_t ledBreathPeriodMs;
+  uint8_t  ledBreathLow;
+  uint8_t  waveBaseLevel;
+  uint8_t  waveSwellPeak;
+  uint16_t wavePeriodMs;
+  uint16_t ledCrossfadeMs;
+  uint8_t  ledScaleStepPerTick;
+  uint8_t  mistDutyMax;
+  uint8_t  mistDutyMin;
+  uint8_t  levelDefault;
+  uint16_t mistWaveTroughQ8;
+  uint16_t levelSmoothTickMs;
+  uint8_t  levelSmoothStepUp;
+  uint8_t  levelSmoothStepDn;
+  uint8_t  levelSmoothStepUpFast;
+  uint16_t levelRampTickMs;
+  uint8_t  levelRampStep;
+  uint16_t buttonDebounceMs;
+  uint16_t buttonLongPressMs;
+  uint16_t buttonLongTickMs;
+  uint16_t reedInsertDwellMs;
+  uint16_t reedRemoveDwellMs;
+  uint8_t  statusLedDimDuty;
+} __attribute__((packed));
+
 // Load defaults, then overlay NVS if a valid blob exists.
 void configInit();
 // Persist the current `cfg` to NVS. Returns false on NVS error.

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -17,36 +17,9 @@ static constexpr const char* KEY_OTA_PW   = "ota_pw";
 
 Config cfg;
 
-// The exact byte layout we persist for KEY_BLOB. Plain POD, no padding
-// surprises across rebuilds because every field is byte/u16-aligned and we
-// don't include the C-string fields here.
-struct CfgBlob {
-  uint8_t  version;
-  uint8_t  ledBreathPeak;
-  uint16_t ledBreathPeriodMs;
-  uint8_t  ledBreathLow;
-  uint8_t  waveBaseLevel;
-  uint8_t  waveSwellPeak;
-  uint16_t wavePeriodMs;
-  uint16_t ledCrossfadeMs;
-  uint8_t  ledScaleStepPerTick;
-  uint8_t  mistDutyMax;
-  uint8_t  mistDutyMin;
-  uint8_t  levelDefault;
-  uint16_t mistWaveTroughQ8;
-  uint16_t levelSmoothTickMs;
-  uint8_t  levelSmoothStepUp;
-  uint8_t  levelSmoothStepDn;
-  uint8_t  levelSmoothStepUpFast;
-  uint16_t levelRampTickMs;
-  uint8_t  levelRampStep;
-  uint16_t buttonDebounceMs;
-  uint16_t buttonLongPressMs;
-  uint16_t buttonLongTickMs;
-  uint16_t reedInsertDwellMs;
-  uint16_t reedRemoveDwellMs;
-  uint8_t  statusLedDimDuty;
-} __attribute__((packed));
+// CfgBlob byte-layout lives in config.h — the Arduino IDE auto-generates
+// forward declarations for the helpers below ABOVE this file, so a struct
+// defined here wouldn't be visible to them.
 
 // --------------------------------------------------------------------------
 // SHA-256 helper (mbedtls is bundled with arduino-esp32 core).
@@ -60,10 +33,12 @@ void configSha256Hex(const char* in, size_t inLen, char outHex[CFG_SHA256_HEX_LE
   mbedtls_sha256_update(&ctx, (const unsigned char*)in, inLen);
   mbedtls_sha256_finish(&ctx, digest);
   mbedtls_sha256_free(&ctx);
-  static const char* HEX = "0123456789abcdef";
+  // Arduino's Print.h #defines HEX as 16 for Serial.print(value, HEX). Use a
+  // distinct name here to avoid the preprocessor mangling our string literal.
+  static const char* HEX_CHARS = "0123456789abcdef";
   for (int i = 0; i < 32; ++i) {
-    outHex[i * 2 + 0] = HEX[(digest[i] >> 4) & 0xF];
-    outHex[i * 2 + 1] = HEX[digest[i] & 0xF];
+    outHex[i * 2 + 0] = HEX_CHARS[(digest[i] >> 4) & 0xF];
+    outHex[i * 2 + 1] = HEX_CHARS[digest[i] & 0xF];
   }
   outHex[CFG_SHA256_HEX_LEN] = '\0';
 }
@@ -281,14 +256,17 @@ bool configSetOtaPassword(const char* pwd) {
 // Field updates (used by /api/config). Each entry validates its own range.
 // --------------------------------------------------------------------------
 
-#define SET_U8(field, name, lo, hi) \
-  if (strcmp(field, name) == 0) { \
+// `name` is the runtime field-name argument (the function's parameter).
+// `member` is the Config struct member identifier we want to assign to.
+// `key` is the string literal we compare `name` against.
+#define SET_U8(member, key, lo, hi) \
+  if (strcmp(name, (key)) == 0) { \
     if (value < (lo) || value > (hi)) return false; \
-    cfg.field = uint8_t(value); return true; }
-#define SET_U16(field, name, lo, hi) \
-  if (strcmp(field, name) == 0) { \
+    cfg.member = uint8_t(value); return true; }
+#define SET_U16(member, key, lo, hi) \
+  if (strcmp(name, (key)) == 0) { \
     if (value < (lo) || value > (hi)) return false; \
-    cfg.field = uint16_t(value); return true; }
+    cfg.member = uint16_t(value); return true; }
 
 bool configSetField(const char* name, long value) {
   if (!name) return false;

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -24,6 +24,7 @@
 
 #include <WebServer.h>
 #include <WiFi.h>
+#include <mbedtls/base64.h>
 #include "pins.h"
 #include "config.h"
 #include "web_ui.h"
@@ -85,7 +86,6 @@ static bool requireAuth() {
   // arduino-esp32 ships a `mbedtls_base64_decode`; use it.
   uint8_t buf[96];
   size_t  outLen = 0;
-  extern int mbedtls_base64_decode(unsigned char*, size_t, size_t*, const unsigned char*, size_t);
   if (mbedtls_base64_decode(buf, sizeof(buf) - 1, &outLen,
                             (const unsigned char*)b64.c_str(), b64.length()) != 0) {
     g_http.send(401, "application/json", "{\"error\":\"bad base64\"}");
@@ -106,7 +106,11 @@ static bool requireAuth() {
   return true;
 }
 
-static const char* stateName(AppState s) {
+// Local copy: `stateName` lives as `static` in BlockKit_Production.ino and
+// Arduino concatenates all .ino files into one translation unit, so two
+// `static const char* stateName(...)` definitions in the same TU collide.
+// Renamed here to avoid the duplicate.
+static const char* webStateName(AppState s) {
   switch (s) {
     case AppState::IDLE:                    return "IDLE";
     case AppState::RUNNING:                 return "RUNNING";
@@ -132,7 +136,7 @@ static size_t buildStatusJson(char* out, size_t cap) {
     "\"uptimeMs\":%lu,"
     "\"freeHeap\":%u,"
     "\"rssi\":%d}",
-    stateName(appCurrentState()),
+    webStateName(appCurrentState()),
     unsigned(appCurrentState()),
     digitalRead(PIN_BUTTON),
     digitalRead(PIN_REED) == LOW ? 1 : 0,


### PR DESCRIPTION
## Summary

Hotfix for the Block Kit Production sketch — five compile errors caught when building in the Arduino IDE 2.x after PR #7 landed. Each error in the build log gets a direct fix.

| # | Error | Fix |
|---|---|---|
| 1 | `'CfgBlob' was not declared in this scope` in `packBlob`/`unpackBlob` | Move `struct CfgBlob` from `config.ino` into `config.h`. The Arduino IDE auto-generates forward declarations and inserts them at the TOP of the preprocessed file, before the struct in `config.ino` could be seen. |
| 2 | `expected unqualified-id before numeric constant` on `static const char* HEX = ...` | Rename local to `HEX_CHARS`. Arduino's `Print.h` `#define HEX 16` (the `Serial.print(v, HEX)` formatter) was mangling the string literal name. |
| 3 | `'ledBreathPeak' was not declared in this scope` (and every other member) | Fix the `SET_U8 / SET_U16` macros. The previous macro arg `field` shadowed the function parameter `field` (now `name`), so the expansion produced `strcmp(ledBreathPeak, "ledBreathPeak")` — treating the member identifier as a variable. Macro args renamed to `member` / `key`; the body uses the function's `name` parameter for comparison. |
| 4 | `redefinition of 'const char* stateName(AppState)'` | Rename the copy in `web_server.ino` to `webStateName`. Arduino concatenates all `.ino` files into one TU, so two `static const char* stateName(...)` in different files collide. |
| 5 | (would have surfaced at link time) `extern int mbedtls_base64_decode(...)` in C++ scope without `extern "C"` | Replace with `#include <mbedtls/base64.h>`. mbedtls exports unmangled C symbols; without the header the C++ compiler mangles the name and the linker won't resolve it. |

## Verification

I could not run a full `arduino-cli compile` in this sandbox — outbound HTTPS to `downloads.arduino.cc` and `dl.espressif.com` is blocked (`x-deny-reason: host_not_allowed`), so neither the package index nor the ESP32 platform tools install. Each fix is traceable to a specific line in the build log you posted, and I reviewed the changes statically to confirm no stragglers:

- `grep CfgBlob` → defined once in `config.h`, used in `config.ino` (which includes the header).
- `grep stateName / webStateName` → `stateName` only in `BlockKit_Production.ino`, `webStateName` only in `web_server.ino`. No collision.
- `grep HEX` → only `HEX_CHARS` remains.
- `grep "extern.*mbedtls"` → zero matches; replaced by `#include <mbedtls/base64.h>`.

Please re-verify with your local Arduino IDE before merging — the `WiFi.h` "multiple libraries" line was a warning, not an error, and won't change here.

## Test plan

- [ ] Open `BlockKit_Production.ino` in Arduino IDE 2.x, board XIAO_ESP32C6, USB CDC On Boot **Enabled**.
- [ ] Verify compiles cleanly with no errors.
- [ ] Upload. Confirm the boot banner prints, captive portal comes up on first boot, web UI loads on `http://blockkit.local/`.

https://claude.ai/code/session_01Rj4oc8wf9Qb621WjbDsCDM


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rj4oc8wf9Qb621WjbDsCDM)_