### PR TITLE
Simplify Block Kit production firmware (no feature loss)

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/ARCHITECTURE.md
+++ b/variants/block-kit/firmware/BlockKit_Production/ARCHITECTURE.md
@@ -114,8 +114,8 @@ g_ledScale     (0..255)   ← smoothed visibility scaler; eases toward
                             over ~640 ms (step 4 / 10 ms). Multiplies the
                             baseLevel handed to ledRender; mist ignores it.
 
-mist duty   = (computeMistOutLevel(g_currentLevel, now) × MIST_DUTY_MAX) / 255
-              where computeMistOutLevel(level, now) applies the wave-sync
+mist duty   = (mistOutLevel(g_currentLevel, now) × MIST_DUTY_MAX) / 255
+              where mistOutLevel(level, now) applies the wave-sync
               factor:
                 factor (Q8) = MIST_WAVE_TROUGH_Q8
                             + ((256 - MIST_WAVE_TROUGH_Q8) × gauss_at_piezo) >> 8
@@ -157,7 +157,7 @@ Pieces sitting outside the smoother:
 
 | File | Role |
 |---|---|
-| `BlockKit_Test.ino` | state machine, smoother, LED-visibility smoother, wave-mist sync (`computeMistOutLevel`), serial parser, glue |
+| `BlockKit_Production.ino` | state machine, smoother, LED-visibility smoother, wave-mist sync (`mistOutLevel`), serial parser, glue |
 | `pins.h` | pin defs, tunables, enums — single source of truth |
 | `mist.ino` | `mistApply(level)`, `mistHardStop`, boost rail gating, inhibit |
 | `led_driver.ino` | `ledRender(baseLevel)` — renders BREATH (exp(sin) LUT, linear-interp, capped to LED_BREATH_PEAK) or WAVE (gaussian-LUT swell traveling bottom→top), 1.1 s pre-gamma crossfade between modes, gamma + per-LED I2C write cache. Also exposes `waveIntensityAtPiezo(now)` so the main loop can phase-lock mist drive to the wave swell. |
@@ -166,7 +166,7 @@ Pieces sitting outside the smoother:
 | `button.ino` | debounce, short/long-press events |
 | `current_sense.ino` | INA180 ADC @ 1 kHz, rolling mean+variance, scope mode |
 
-Arduino concatenates all `.ino` files into one translation unit, so file-scope `static` only scopes per file by convention — names use module prefixes (`g_btnLastTickMs`, `g_ledLastRenderMs`, …) to avoid collisions.
+Arduino concatenates all `.ino` files into one translation unit, so file-scope `static` only scopes per file by convention — names use module prefixes (`g_longPressTickMs`, `g_ledLastRenderMs`, …) to avoid collisions.
 
 ## Serial Commands (115200 baud)
 
@@ -277,7 +277,7 @@ subsystem (LED driver, smoother) misbehaves.
 
 ## Transition cinematic (post-PR-#6 polish)
 
-`enterIdle()` no longer sets `g_fastFadeUp = true` when called from
+`enterIdle()` no longer sets `g_fastLevelUp = true` when called from
 TRANSITION_FROM_RUNNING. The breath restore uses the slow smoother
 step (~1.3 s 0→255) instead of the original brisk (~640 ms) restore.
 Combined with the 1.1 s WAVE→BREATH crossfade, the post-removal

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -50,19 +50,17 @@ void      appToggleLedsHidden();
 void      appKickLedWalk();
 
 // ---- App-level state ----
-static AppState g_state           = AppState::IDLE;  // boot default = soft breath
-static uint8_t  g_userLevel       = CFG_DEFAULT_LEVEL_DEFAULT;   // user's set level (long-press adjusts); overwritten in setup() once cfg is loaded
-static uint8_t  g_targetLevel     = 0;               // state-driven target for the smoother
-static uint8_t  g_currentLevel    = 0;               // smoothed actual level applied to mist+LEDs
-static int8_t   g_levelAdjustDir          = -1;              // -1 = next long-press dims, +1 = brightens
-static uint32_t g_lastSmoothMs    = 0;
-static uint32_t g_lastRampMs      = 0;
-static uint32_t g_lastStatPrintMs      = 0;
-// One-shot flag: use the fast STEP_UP for the next 0→target ramp. Set when
-// entering IDLE from TRANSITION_FROM_RUNNING so the breath restore
-// after a container lift feels brisk (~640 ms) rather than luxurious (~1.3 s).
-// Cleared automatically once the smoother reaches target.
-static bool     g_fastLevelUp      = false;
+static AppState g_state             = AppState::IDLE;  // boot default = soft breath
+static uint8_t  g_userLevel         = CFG_DEFAULT_LEVEL_DEFAULT;  // overwritten from cfg in setup()
+static uint8_t  g_targetLevel       = 0;    // state-driven target for the smoother
+static uint8_t  g_currentLevel      = 0;    // smoothed level applied to mist+LEDs
+static int8_t   g_levelAdjustDir    = -1;   // -1 = next long-press dims, +1 = brightens
+static uint32_t g_lastSmoothMs      = 0;
+static uint32_t g_lastRampMs        = 0;
+static uint32_t g_lastStatPrintMs   = 0;
+// One-shot: pick the fast step for the next upward ramp (post-lift restore).
+// Cleared once the smoother reaches target.
+static bool     g_fastLevelUp       = false;
 
 // LED visibility — orthogonal to AppState. Short-press toggles g_ledsHidden;
 // a separate smoother fades g_ledScale 0↔255 over ~640 ms, multiplying the

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -232,61 +232,49 @@ static void setLedsHidden(bool hidden) {
 void appToggleLedsHidden() { setLedsHidden(!g_ledsHidden); }
 
 // ----------------------------------------------------------------------
-// Level smoother — runs every cfg.levelSmoothTickMs, advances g_currentLevel
-// toward g_targetLevel. Tuned for ~1.3 s 0→255 ramp normally (step 2 per
-// 10 ms — tiny enough that the eye reads it as a continuous slide, not a
-// staircase); ~0.85 s 255→0; ~0.64 s when g_fastFadeUp is set (one-shot,
-// used to make the post-removal breath restore feel brisk).
-//
-// One state-machine side effect fires here: when the smoother lands on 0
-// while in TRANSITION_FROM_RUNNING, auto-enter IDLE to kick off the
-// WAVE→BREATH crossfade as the breath fades back in. The RUNNING-side
-// "fade up then engage swirl" two-step from the prior design is gone —
-// led_driver crossfades BREATH↔WAVE directly the moment ledSetMode is
-// called, so the smoother no longer drives mode changes.
+// Generic asymmetric ramp — pure, no globals. One step up, a different step
+// down (use the same value for symmetric easing). Clamps at target so we
+// never overshoot.
 // ----------------------------------------------------------------------
+static uint8_t rampToward(uint8_t current, uint8_t target, uint8_t stepUp, uint8_t stepDown) {
+  if (current < target) {
+    const uint8_t room = target - current;
+    return current + ((room < stepUp) ? room : stepUp);
+  }
+  if (current > target) {
+    const uint8_t room = current - target;
+    return current - ((room < stepDown) ? room : stepDown);
+  }
+  return current;
+}
+
+// Level smoother — runs every cfg.levelSmoothTickMs. Asymmetric: a one-shot
+// fast lane (g_fastFadeUp) lets the post-lift breath restore feel brisk.
+// State-machine side effect: when the smoother lands on 0 in
+// TRANSITION_FROM_RUNNING, auto-enter IDLE to start the WAVE→BREATH crossfade.
 static void smoothLevel() {
   const uint32_t now = millis();
   if (now - g_lastSmoothMs < cfg.levelSmoothTickMs) return;
   g_lastSmoothMs = now;
 
-  if (g_currentLevel < g_targetLevel) {
-    const uint8_t step = g_fastFadeUp ? cfg.levelSmoothStepUpFast : cfg.levelSmoothStepUp;
-    const uint8_t room = g_targetLevel - g_currentLevel;
-    g_currentLevel += (room < step) ? room : step;
-  } else if (g_currentLevel > g_targetLevel) {
-    const uint8_t room = g_currentLevel - g_targetLevel;
-    g_currentLevel -= (room < cfg.levelSmoothStepDn) ? room : cfg.levelSmoothStepDn;
-  }
+  const uint8_t stepUp = g_fastFadeUp ? cfg.levelSmoothStepUpFast : cfg.levelSmoothStepUp;
+  g_currentLevel = rampToward(g_currentLevel, g_targetLevel, stepUp, cfg.levelSmoothStepDn);
 
   if (g_currentLevel != g_targetLevel) return;
-
-  // Landed on target.
   g_fastFadeUp = false;
   if (g_state == AppState::TRANSITION_FROM_RUNNING && g_targetLevel == 0) {
-    enterIdle();                           // kicks off WAVE→BREATH crossfade
+    enterIdle();
   }
 }
 
-// ----------------------------------------------------------------------
-// LED visibility scaler smoother — independent of the level smoother. Eases
-// g_ledScale toward g_ledScaleTarget (0 or 255) over ~640 ms so the strip
-// fades cleanly when the short-press toggles g_ledsHidden. Mist is NOT
-// gated by this scaler.
-// ----------------------------------------------------------------------
+// LED visibility smoother — symmetric fade for the short-press hide/show
+// toggle. Mist is intentionally NOT gated by this scaler.
 static void smoothLedScale() {
   const uint32_t now = millis();
   if (now - g_lastLedScaleMs < cfg.levelSmoothTickMs) return;
   g_lastLedScaleMs = now;
-
-  const uint8_t step = cfg.ledScaleStepPerTick;
-  if (g_ledScale < g_ledScaleTarget) {
-    const uint8_t room = g_ledScaleTarget - g_ledScale;
-    g_ledScale += (room < step) ? room : step;
-  } else if (g_ledScale > g_ledScaleTarget) {
-    const uint8_t room = g_ledScale - g_ledScaleTarget;
-    g_ledScale -= (room < step) ? room : step;
-  }
+  g_ledScale = rampToward(g_ledScale, g_ledScaleTarget,
+                          cfg.ledScaleStepPerTick, cfg.ledScaleStepPerTick);
 }
 
 // ----------------------------------------------------------------------

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -1,69 +1,19 @@
-// Block Kit V0.1 — bring-up firmware (Phase A).
+// Block Kit V0.1 — production firmware (Phase A).
 //
-// Phase A scope: mist control + reed switch (magnetic-on UX) + button override
-// + dual-mode LED effects (deep-dim breath / soft gaussian swell wave) + D7
-// dim indicator + scope-mode current logging. The water-level classifier
-// (Phase B) is intentionally NOT in this build.
+// Top-level state machine + main loop. Three container-driven states drive
+// the mist and LED ring; an orthogonal g_ledsHidden flag (short-press toggle)
+// fades the LED strip without touching mist.
 //
-// State machine — three container-driven states, plus an orthogonal
-// `g_ledsHidden` boolean that's toggled by the short-press button:
+//   IDLE                    — undocked: soft exp(sin) breath on all 14 LEDs.
+//   RUNNING                 — docked: gaussian swell wave + wave-modulated mist.
+//   TRANSITION_FROM_RUNNING — just lifted: mist hard-stops, wave dims to 0.
 //
-//   IDLE                    — DEFAULT idle: container undocked, LED strip
-//                             holding a *very dim, dramatic* exp(sin) breath
-//                             — the exhale lingers at full black for a beat.
-//                             Boot lands here.
-//   RUNNING                 — container docked, mist active and PULSING in
-//                             sync with the LED wave (see "Wave-mist sync"
-//                             below). LED strip runs the WAVE animation:
-//                             every LED always lit at a baseline, plus a
-//                             single slow gaussian swell traveling bottom→
-//                             top. The BREATH→WAVE swap on docking is a
-//                             1.1 s crossfade — no snap.
-//   TRANSITION_FROM_RUNNING — container just lifted: mist hard-stopped,
-//                             wave dims to 0 (mode stays WAVE during the dim
-//                             so it reads as continuous), then auto-enters
-//                             IDLE which kicks off the WAVE→BREATH
-//                             crossfade as the breath fades back in. Re-
-//                             docking during this transition cleanly re-
-//                             enters RUNNING.
+// Wave-mist sync: while RUNNING, mist drive is gated by the wave's gaussian
+// sampled 1 LED above the strip (the piezo's physical position). See
+// computeMistOutLevel() here + waveIntensityAtPiezo() in led_driver.ino.
 //
-// Orthogonal: `g_ledsHidden` (short-press toggle) hides the LED strip only.
-// The mist keeps running at the user-set level regardless of the flag, so
-// short-pressing is *not* a kill switch — it's a "blank the visuals,
-// please" gesture. A separate smoother fades the LED render to 0 over
-// ~640 ms (the wave/breath animation keeps running underneath). The
-// previous design coupled "mute LEDs" with "stop mist"; the new design
-// lets you keep the diffuser working while the room goes dark.
-//
-// One `g_userLevel` variable (0..255) drives both mist PWM duty and LED
-// brightness scale. Mist duty = (level * cfg.mistDutyMax) / 255 so level=255
-// means 50% duty (full mist). `g_targetLevel` is what each state wants the
-// level to be; `smoothLevel()` ramps `g_currentLevel` toward target with
-// step=2 per 10 ms tick (~1.3 s 0→255) so every fade feels continuous, not
-// stepped — addressing the prior "snappy" complaint.
-//
-// Wave-mist sync (RUNNING only):
-//   While in RUNNING, the mist drive level is no longer just g_currentLevel.
-//   It's modulated by the wave's gaussian swell evaluated 1 LED *above*
-//   the top of the strip — where the piezo disc physically sits. Result:
-//   the mist rises as the swell rises up the LEDs, peaks once the wave has
-//   visibly crossed the top (because that's when the wave reaches the
-//   piezo), then dims down together with the top LED as the wave continues
-//   off-screen above. At max user level the mist swings between ~36 % and
-//   100 % of full — visible pulse, but proportional to the wave's own
-//   trough-to-peak ratio so the two motions feel like one motion. See
-//   `computeMistOutLevel()` below and `waveIntensityAtPiezo()` in
-//   led_driver.ino.
-//
-// Container lift is a SAFETY event: mist hard-stops the moment the reed
-// opens (mistHardStop), while the LED smoother continues the visual fade.
-// Everything else uses the smooth path.
-//
-// The LED ring is a 14-LED vertical strip on an IS31FL3731 driver (Matrix
-// B, top=LED 1, bottom=LED 14). All strip animation + per-mode crossfade
-// logic lives in led_driver.ino; this file just flips the mode via
-// ledSetMode() at the right state transitions and the LED driver handles
-// the rest.
+// SAFETY: container lift hard-stops mist (mistEnable(false)); OTA upload
+// hard-stops mist (see ota.ino); boost rail is forced LOW first in setup().
 
 #include <Wire.h>
 #include "pins.h"

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -10,7 +10,7 @@
 //
 // Wave-mist sync: while RUNNING, mist drive is gated by the wave's gaussian
 // sampled 1 LED above the strip (the piezo's physical position). See
-// computeMistOutLevel() here + waveIntensityAtPiezo() in led_driver.ino.
+// mistOutLevel() here + waveIntensityAtPiezo() in led_driver.ino.
 //
 // SAFETY: container lift hard-stops mist (mistEnable(false)); OTA upload
 // hard-stops mist (see ota.ino); boost rail is forced LOW first in setup().
@@ -54,15 +54,15 @@ static AppState g_state           = AppState::IDLE;  // boot default = soft brea
 static uint8_t  g_userLevel       = CFG_DEFAULT_LEVEL_DEFAULT;   // user's set level (long-press adjusts); overwritten in setup() once cfg is loaded
 static uint8_t  g_targetLevel     = 0;               // state-driven target for the smoother
 static uint8_t  g_currentLevel    = 0;               // smoothed actual level applied to mist+LEDs
-static int8_t   g_dimDir          = -1;              // -1 = next long-press dims, +1 = brightens
+static int8_t   g_levelAdjustDir          = -1;              // -1 = next long-press dims, +1 = brightens
 static uint32_t g_lastSmoothMs    = 0;
 static uint32_t g_lastRampMs      = 0;
-static uint32_t g_lastStatMs      = 0;
+static uint32_t g_lastStatPrintMs      = 0;
 // One-shot flag: use the fast STEP_UP for the next 0→target ramp. Set when
 // entering IDLE from TRANSITION_FROM_RUNNING so the breath restore
 // after a container lift feels brisk (~640 ms) rather than luxurious (~1.3 s).
 // Cleared automatically once the smoother reaches target.
-static bool     g_fastFadeUp      = false;
+static bool     g_fastLevelUp      = false;
 
 // LED visibility — orthogonal to AppState. Short-press toggles g_ledsHidden;
 // a separate smoother fades g_ledScale 0↔255 over ~640 ms, multiplying the
@@ -101,13 +101,13 @@ static void enterIdle() {
   // With the slow step (~1.3 s 0→255), the breath emerges gently and the
   // 1.1 s WAVE→BREATH crossfade has time to dissolve naturally. Net
   // experience: dim down to dark, then a soft breath swells in instead
-  // of snapping on. (The g_fastFadeUp lane is still used by other code
+  // of snapping on. (The g_fastLevelUp lane is still used by other code
   // paths if anything else needs it.)
   if (g_state == AppState::IDLE) return;
   const bool leavingMist = mistMayBeActive(g_state);
   g_state = AppState::IDLE;
   g_targetLevel = g_userLevel;
-  g_fastFadeUp = false;            // slow restore — see comment at top of enterIdle()
+  g_fastLevelUp = false;            // slow restore — see comment at top of enterIdle()
   // BREATH triggers the WAVE→BREATH crossfade in led_driver when coming
   // from RUNNING / TRANSITION. led_driver collapses no-op mode changes
   // for us if we were already BREATH (e.g. boot).
@@ -127,7 +127,7 @@ static void enterRunning() {
   // landed at target; that produced a visible "fade up then snap to chase"
   // moment — the specific complaint we're fixing here.
   ledSetMode(LedMode::WAVE);
-  g_fastFadeUp = false;
+  g_fastLevelUp = false;
   mistEnable(true);                        // re-arm the mist path
   Serial.println("[APP] -> RUNNING");
 }
@@ -140,7 +140,7 @@ static void enterTransitionFromRunning() {
   // ramps 255→0 (it scales the whole render uniformly). When the smoother
   // lands at 0 it auto-enters IDLE which kicks off the WAVE→BREATH
   // crossfade for the restore.
-  g_fastFadeUp = false;
+  g_fastLevelUp = false;
   mistEnable(false);                       // hard-stop + inhibit
   Serial.println("[APP] -> TRANSITION_FROM_RUNNING");
 }
@@ -156,7 +156,7 @@ static void enterTransitionFromRunning() {
 // piezo position (1 LED above the top), so the mist crest follows the
 // wave crest *across the top of the strip*, not at any visible LED.
 // ----------------------------------------------------------------------
-static uint8_t computeMistOutLevel(uint32_t now) {
+static uint8_t mistOutLevel(uint32_t now) {
   if (g_currentLevel == 0) return 0;
   const uint16_t trough = cfg.mistWaveTroughQ8;
   const uint16_t gauss  = uint16_t(waveIntensityAtPiezo(now));
@@ -199,7 +199,7 @@ static uint8_t rampToward(uint8_t current, uint8_t target, uint8_t stepUp, uint8
 }
 
 // Level smoother — runs every cfg.levelSmoothTickMs. Asymmetric: a one-shot
-// fast lane (g_fastFadeUp) lets the post-lift breath restore feel brisk.
+// fast lane (g_fastLevelUp) lets the post-lift breath restore feel brisk.
 // State-machine side effect: when the smoother lands on 0 in
 // TRANSITION_FROM_RUNNING, auto-enter IDLE to start the WAVE→BREATH crossfade.
 static void smoothLevel() {
@@ -207,11 +207,11 @@ static void smoothLevel() {
   if (now - g_lastSmoothMs < cfg.levelSmoothTickMs) return;
   g_lastSmoothMs = now;
 
-  const uint8_t stepUp = g_fastFadeUp ? cfg.levelSmoothStepUpFast : cfg.levelSmoothStepUp;
+  const uint8_t stepUp = g_fastLevelUp ? cfg.levelSmoothStepUpFast : cfg.levelSmoothStepUp;
   g_currentLevel = rampToward(g_currentLevel, g_targetLevel, stepUp, cfg.levelSmoothStepDn);
 
   if (g_currentLevel != g_targetLevel) return;
-  g_fastFadeUp = false;
+  g_fastLevelUp = false;
   if (g_state == AppState::TRANSITION_FROM_RUNNING && g_targetLevel == 0) {
     enterIdle();
   }
@@ -234,12 +234,12 @@ static void smoothLedScale() {
 // anymore — turning the device "off" is a separate gesture (short-press
 // hides the LEDs, lifting the container hard-stops the mist).
 // ----------------------------------------------------------------------
-static void rampUserLevel() {
+static void rampLevel() {
   const uint32_t now = millis();
   if (now - g_lastRampMs < cfg.levelRampTickMs) return;
   g_lastRampMs = now;
 
-  int16_t v = int16_t(g_userLevel) + int16_t(g_dimDir) * int16_t(cfg.levelRampStep);
+  int16_t v = int16_t(g_userLevel) + int16_t(g_levelAdjustDir) * int16_t(cfg.levelRampStep);
   if (v < 0)   v = 0;
   if (v > 255) v = 255;
   g_userLevel = uint8_t(v);
@@ -262,7 +262,7 @@ static void printHelp() {
   Serial.println(F("  m             - mute / unmute the [PLOT] stream"));
 }
 
-static long parseTail(const char* cmd, uint8_t len) {
+static long parseNumberArg(const char* cmd, uint8_t len) {
   if (len < 2) return -1;
   long v = 0;
   for (uint8_t i = 1; i < len; ++i) {
@@ -291,7 +291,7 @@ static void handleCommand(const char* cmd, uint8_t len) {
       setLedsHidden(!g_ledsHidden);
       return;
     case 'v': {
-      const long v = parseTail(cmd, len);
+      const long v = parseNumberArg(cmd, len);
       if (v < 0 || v > 255) { Serial.println("[CMD] v: 0..255"); return; }
       g_userLevel = uint8_t(v);
       // IDLE and RUNNING both follow user level live; TRANSITION_FROM_RUNNING
@@ -376,18 +376,18 @@ static void onButtonEvent(ButtonEvent ev) {
       if (g_state != AppState::TRANSITION_FROM_RUNNING) {
         g_lastRampMs = millis();
         Serial.print("[BTN] long-press start, dir=");
-        Serial.println(int(g_dimDir));
+        Serial.println(int(g_levelAdjustDir));
       }
       return;
     case ButtonEvent::LongPressTick:
       if (g_state != AppState::TRANSITION_FROM_RUNNING) {
-        rampUserLevel();
+        rampLevel();
       }
       return;
     case ButtonEvent::LongPressEnd:
-      g_dimDir = -g_dimDir;
+      g_levelAdjustDir = -g_levelAdjustDir;
       Serial.print("[BTN] long-press end, next dir=");
-      Serial.println(int(g_dimDir));
+      Serial.println(int(g_levelAdjustDir));
       return;
     default: return;
   }
@@ -405,10 +405,10 @@ static const char* stateName(AppState s) {
   return "?";
 }
 
-static void statTick() {
+static void statusTick() {
   const uint32_t now = millis();
-  if (now - g_lastStatMs < 1000) return;
-  g_lastStatMs = now;
+  if (now - g_lastStatPrintMs < 1000) return;
+  g_lastStatPrintMs = now;
   Serial.print("[STAT] state=");       Serial.print(stateName(g_state));
   Serial.print(" leds=");              Serial.print(g_ledsHidden ? "hidden" : "visible");
   Serial.print(" reed=");              Serial.print(containerRawPresent() ? 1 : 0);
@@ -511,7 +511,7 @@ void loop() {
   // mist is inhibited everywhere else, so mistApply is a no-op there).
   // LEDs: scaled by g_ledScale (the short-press hide/show fade) so the
   // strip can be blanked without touching mist.
-  mistApply(computeMistOutLevel(now));
+  mistApply(mistOutLevel(now));
   const uint8_t ledBase =
       uint8_t((uint16_t(g_currentLevel) * uint16_t(g_ledScale)) >> 8);
   ledRender(ledBase);
@@ -527,7 +527,7 @@ void loop() {
   statusLedSet(!containerIsPresent());
 
   currentSenseLogPlot(uint8_t(g_state));
-  statTick();
+  statusTick();
 
   // Web UI may request a one-shot LED chase via /api/cmd/walk.
   if (g_kickLedWalk) {

--- a/variants/block-kit/firmware/BlockKit_Production/button.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/button.ino
@@ -32,10 +32,10 @@ ButtonEvent buttonPoll() {
     return ButtonEvent::None;
   }
 
-  // Debounce gate.
   if (now - g_lastChangeMs < cfg.buttonDebounceMs) return ButtonEvent::None;
+
   if (raw == g_debounced) {
-    // Still pressed — emit long-press start once the threshold passes, then ticks.
+    // Still pressed — emit long-press start once threshold passes, then ticks.
     if (g_debounced) {
       if (!g_longActive && (now - g_pressStartMs >= cfg.buttonLongPressMs)) {
         g_longActive = true;
@@ -50,16 +50,12 @@ ButtonEvent buttonPoll() {
     return ButtonEvent::None;
   }
 
-  // Committed state changes here.
   g_debounced = raw;
   if (raw) {
-    // Press down.
     g_pressStartMs = now;
     g_longActive = false;
     return ButtonEvent::None;
   }
-
-  // Release.
   if (g_longActive) {
     g_longActive = false;
     return ButtonEvent::LongPressEnd;

--- a/variants/block-kit/firmware/BlockKit_Production/button.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/button.ino
@@ -5,12 +5,12 @@
 #include "pins.h"
 #include "config.h"
 
-static bool     g_lastRaw         = false;  // last raw read
-static bool     g_debounced       = false;  // committed debounced state
+static bool     g_buttonLastRaw         = false;  // last raw read
+static bool     g_buttonState       = false;  // committed debounced state
 static uint32_t g_lastChangeMs    = 0;
 static uint32_t g_pressStartMs    = 0;
-static bool     g_longActive      = false;
-static uint32_t g_btnLastTickMs      = 0;
+static bool     g_inLongPress      = false;
+static uint32_t g_longPressTickMs      = 0;
 
 void buttonInit() {
   // PCB has an external 10 k pull-down on D6. Enabling INPUT_PULLDOWN in
@@ -26,38 +26,38 @@ ButtonEvent buttonPoll() {
   const bool raw = (digitalRead(PIN_BUTTON) == HIGH);
   const uint32_t now = millis();
 
-  if (raw != g_lastRaw) {
-    g_lastRaw = raw;
+  if (raw != g_buttonLastRaw) {
+    g_buttonLastRaw = raw;
     g_lastChangeMs = now;
     return ButtonEvent::None;
   }
 
   if (now - g_lastChangeMs < cfg.buttonDebounceMs) return ButtonEvent::None;
 
-  if (raw == g_debounced) {
+  if (raw == g_buttonState) {
     // Still pressed — emit long-press start once threshold passes, then ticks.
-    if (g_debounced) {
-      if (!g_longActive && (now - g_pressStartMs >= cfg.buttonLongPressMs)) {
-        g_longActive = true;
-        g_btnLastTickMs = now;
+    if (g_buttonState) {
+      if (!g_inLongPress && (now - g_pressStartMs >= cfg.buttonLongPressMs)) {
+        g_inLongPress = true;
+        g_longPressTickMs = now;
         return ButtonEvent::LongPressStart;
       }
-      if (g_longActive && (now - g_btnLastTickMs >= cfg.buttonLongTickMs)) {
-        g_btnLastTickMs = now;
+      if (g_inLongPress && (now - g_longPressTickMs >= cfg.buttonLongTickMs)) {
+        g_longPressTickMs = now;
         return ButtonEvent::LongPressTick;
       }
     }
     return ButtonEvent::None;
   }
 
-  g_debounced = raw;
+  g_buttonState = raw;
   if (raw) {
     g_pressStartMs = now;
-    g_longActive = false;
+    g_inLongPress = false;
     return ButtonEvent::None;
   }
-  if (g_longActive) {
-    g_longActive = false;
+  if (g_inLongPress) {
+    g_inLongPress = false;
     return ButtonEvent::LongPressEnd;
   }
   return ButtonEvent::ShortPress;

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -142,6 +142,15 @@ static void unpackBlob(const CfgBlob& b) {
 // NVS init / save
 // --------------------------------------------------------------------------
 
+// Helper: write one NVS string and close. Returns false on NVS open failure.
+static bool nvsPutString(const char* key, const char* value) {
+  Preferences p;
+  if (!p.begin(NS, /*readOnly=*/false)) return false;
+  p.putString(key, value);
+  p.end();
+  return true;
+}
+
 void configInit() {
   configResetDefaults();
 
@@ -212,11 +221,7 @@ bool configSetHostname(const char* name) {
   if (name[0] == '-' || name[n - 1] == '-') return false;
   strncpy(cfg.hostname, name, CFG_HOSTNAME_MAX);
   cfg.hostname[CFG_HOSTNAME_MAX] = '\0';
-  Preferences p;
-  if (!p.begin(NS, false)) return false;
-  p.putString(KEY_HOST, cfg.hostname);
-  p.end();
-  return true;
+  return nvsPutString(KEY_HOST, cfg.hostname);
 }
 
 bool configSetAdminPassword(const char* pwd) {
@@ -224,11 +229,7 @@ bool configSetAdminPassword(const char* pwd) {
   const size_t n = strlen(pwd);
   if (n < 4 || n > 64) return false;       // min 4 chars (low bar; let's not get in the way)
   configSha256Hex(pwd, n, cfg.adminPasswordHash);
-  Preferences p;
-  if (!p.begin(NS, false)) return false;
-  p.putString(KEY_ADMIN_PW, cfg.adminPasswordHash);
-  p.end();
-  return true;
+  return nvsPutString(KEY_ADMIN_PW, cfg.adminPasswordHash);
 }
 
 bool configCheckAdminPassword(const char* pwd) {
@@ -245,11 +246,7 @@ bool configSetOtaPassword(const char* pwd) {
   if (n > CFG_OTA_PWD_MAX) return false;
   strncpy(cfg.otaPassword, pwd, CFG_OTA_PWD_MAX);
   cfg.otaPassword[CFG_OTA_PWD_MAX] = '\0';
-  Preferences p;
-  if (!p.begin(NS, false)) return false;
-  p.putString(KEY_OTA_PW, cfg.otaPassword);
-  p.end();
-  return true;
+  return nvsPutString(KEY_OTA_PW, cfg.otaPassword);
 }
 
 // --------------------------------------------------------------------------

--- a/variants/block-kit/firmware/BlockKit_Production/current_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/current_sense.ino
@@ -9,10 +9,10 @@
 #include "pins.h"
 
 static uint16_t g_window[CURRENT_WINDOW_N] = {0};
-static uint16_t g_widx       = 0;
-static uint32_t g_sum        = 0;    // sum of raw ADC counts in window
-static uint64_t g_sumSq      = 0;    // sum of squares
-static uint16_t g_filled     = 0;    // count of samples seen, capped at N
+static uint16_t g_windowWriteIdx       = 0;
+static uint32_t g_windowSum       = 0;    // sum of raw ADC counts in window
+static uint64_t g_windowSumSquares      = 0;    // sum of squares
+static uint16_t g_windowFilled     = 0;    // count of samples seen, capped at N
 
 static uint32_t g_lastSampleUs   = 0;
 static bool     g_scopeMode      = false;
@@ -31,9 +31,9 @@ void currentSenseInit() {
   // Pre-seed the window with one read so the first mean is sensible.
   const uint16_t s = analogRead(PIN_CURRENT_ADC);
   for (uint16_t i = 0; i < CURRENT_WINDOW_N; ++i) g_window[i] = s;
-  g_sum = uint32_t(s) * CURRENT_WINDOW_N;
-  g_sumSq = uint64_t(s) * uint64_t(s) * CURRENT_WINDOW_N;
-  g_filled = CURRENT_WINDOW_N;
+  g_windowSum= uint32_t(s) * CURRENT_WINDOW_N;
+  g_windowSumSquares = uint64_t(s) * uint64_t(s) * CURRENT_WINDOW_N;
+  g_windowFilled = CURRENT_WINDOW_N;
 }
 
 // Convert a raw ADC count (0..4095, 0..3.3 V) to milliamps via INA180A3.
@@ -44,18 +44,18 @@ static inline float adcToMa(uint16_t raw) {
 
 // Rolling mean of the window, in mA.
 float currentMeanMa() {
-  if (g_filled == 0) return 0.0f;
-  const float meanRaw = float(g_sum) / float(g_filled);
+  if (g_windowFilled == 0) return 0.0f;
+  const float meanRaw = float(g_windowSum) / float(g_windowFilled);
   return adcToMa(uint16_t(meanRaw));
 }
 
 // Rolling variance of the window, in mA^2. Useful only as a relative number
 // while we figure out the threshold — print, don't rely on yet.
 float currentVarMa2() {
-  if (g_filled < 2) return 0.0f;
-  const float n = float(g_filled);
-  const float mean = float(g_sum) / n;
-  const float meanSq = float(g_sumSq) / n;
+  if (g_windowFilled < 2) return 0.0f;
+  const float n = float(g_windowFilled);
+  const float mean = float(g_windowSum) / n;
+  const float meanSq = float(g_windowSumSquares) / n;
   const float varRaw = meanSq - mean * mean;
   // Convert variance from raw ADC counts^2 to mA^2.
   const float countToMa = (3.3f * 1000.0f) / (4095.0f * CURRENT_SENSE_FACTOR);
@@ -71,12 +71,12 @@ void currentSenseTick() {
   const uint16_t s = analogRead(PIN_CURRENT_ADC);
 
   // Subtract the slot we're about to overwrite, add the new sample.
-  const uint16_t old = g_window[g_widx];
-  g_sum   = g_sum   - old + s;
-  g_sumSq = g_sumSq - uint64_t(old) * uint64_t(old) + uint64_t(s) * uint64_t(s);
-  g_window[g_widx] = s;
-  g_widx = (g_widx + 1) % CURRENT_WINDOW_N;
-  if (g_filled < CURRENT_WINDOW_N) ++g_filled;
+  const uint16_t old = g_window[g_windowWriteIdx];
+  g_windowSum  = g_windowSum  - old + s;
+  g_windowSumSquares = g_windowSumSquares - uint64_t(old) * uint64_t(old) + uint64_t(s) * uint64_t(s);
+  g_window[g_windowWriteIdx] = s;
+  g_windowWriteIdx = (g_windowWriteIdx + 1) % CURRENT_WINDOW_N;
+  if (g_windowFilled < CURRENT_WINDOW_N) ++g_windowFilled;
 
   // Scope mode: stream raw + mean + var at SCOPE_PRINT_HZ for Serial Plotter.
   if (g_scopeMode && (now - g_lastScopeUs >= (1000000u / SCOPE_PRINT_HZ))) {

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -1,34 +1,8 @@
-// IS31FL3731 driver — premium-ambient rendering for the 14-LED vertical strip.
+// LED ring driver — IS31FL3731 Matrix B, 14-LED vertical strip.
 //
-// Matrix-B addressing: the 14 populated LEDs sit on CB1/CB2 and are written via
-// setLEDPWM(lednum, pwm, 0). drawPixel(x,y,…) writes Matrix A which is unpopulated.
-//
-// Two modes, dispatched by ledSetMode() from the state machine:
-//   BREATH — every LED shares one brightness driven by an exp(sin) curve LUT.
-//            Peak is capped (cfg.ledBreathPeak) so idle stays *very dim and
-//            dramatic*; the exhale lingers at zero. Used while no container
-//            is docked.
-//   WAVE   — every LED is always lit at cfg.waveBaseLevel; on top of that, a
-//            single broad gaussian swell (σ = WAVE_SIGMA_LEDS_Q8) travels
-//            bottom→top slowly, then re-enters from below with no wrap
-//            seam. This is the user-requested "soft swell wave" — NOT a
-//            chase. Used while a container is docked.
-//
-// Mode transitions (BREATH↔WAVE) run an automatic 1.1 s crossfade in pre-gamma
-// space — both modes render every tick during the fade and we linearly blend
-// the raw 0..255 outputs per LED before applying gamma. That's why docking an
-// idle container reads as one smooth dissolve rather than "breath fades up,
-// then snaps to chase".
-//
-// Per-tick pipeline (LED_TICK_MS = 20 ms → 50 fps):
-//   1. Render the current mode's per-LED raw 0..255 brightness.
-//   2. If a crossfade is in progress, also render the previous mode and
-//      linearly blend the two per-LED outputs.
-//   3. Scale the blended raw value by baseLevel (smoothed level from main
-//      loop) so user dimming and state fades affect both modes uniformly.
-//   4. Gamma-correct (2.2 LUT) so the curve feels visually linear.
-//   5. Write through a 14-byte per-LED cache so identical frames produce no
-//      I2C traffic (the dwell at the breath's zero-bottom is a steady state).
+// Two modes (BREATH for idle, WAVE for docked) with an automatic 1.1 s
+// crossfade between them. 50 fps render pipeline: render(s) → blend →
+// scale by baseLevel → gamma → per-LED write cache (skips no-op I2C bursts).
 
 #include <Adafruit_IS31FL3731.h>
 #include "pins.h"

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -34,44 +34,40 @@
 #include "pins.h"
 #include "config.h"
 
-// ---------------------------------------------------------------------------
+// LUT size — 64-entry lookup tables (one inhale/exhale cycle for breath,
+// 0..4σ for gauss). Size is a power of 2 so we can mask instead of mod.
+constexpr uint8_t LUT_SIZE = 64;
+constexpr uint8_t LUT_MASK = LUT_SIZE - 1;   // 0x3F — index wrap for breath
+
+// Gauss LUT covers 4σ in 64 entries → each entry = σ/16 Q8 units = 64.
+// So gauss index = dist_q8 / 64 = dist_q8 >> GAUSS_LUT_SHIFT.
+constexpr uint8_t GAUSS_LUT_SHIFT = 6;       // log2(WAVE_SIGMA_LEDS_Q8 / 16)
+constexpr uint8_t GAUSS_FRAC_LSHIFT = 8 - GAUSS_LUT_SHIFT;  // 0..63 → Q8
+
 // Signed sine LUT — kept for any helper that wants a -127..+127 sine. Not
 // used by the breath or wave renderers directly (those have dedicated LUTs).
-// ---------------------------------------------------------------------------
-static const int8_t SINE_LUT[64] = {
+static const int8_t SINE_LUT[LUT_SIZE] = {
     0,  12,  24,  37,  48,  60,  71,  81,  90,  98, 106, 112, 117, 122, 125, 126,
   127, 126, 125, 122, 117, 112, 106,  98,  90,  81,  71,  60,  48,  37,  24,  12,
     0, -12, -24, -37, -48, -60, -71, -81, -90, -98,-106,-112,-117,-122,-125,-126,
  -127,-126,-125,-122,-117,-112,-106, -98, -90, -81, -71, -60, -48, -37, -24, -12,
 };
 
-// ---------------------------------------------------------------------------
-// exp(sin) BREATH curve LUT — 64 entries, one full inhale/exhale cycle.
-// Each entry = round( 255 * (exp(sin(2π·i/64)) - e⁻¹) / (e − e⁻¹) ).
-//
-// Why exp(sin) instead of plain sine: exp(sin) is asymmetric — it lingers
-// near zero on the exhale (entries ~46..50 sit at 0) and ramps fast on the
-// inhale. That asymmetry is what makes it read as "breathing" rather than
-// "pulsing", and it's also what gives the idle a *dramatic* feel — the
-// strip actually dwells at full black for a beat each cycle instead of
-// dipping and immediately rebounding. This is the same shape FastLED and
-// ThingPulse use for premium breathing-LED effects.
-// ---------------------------------------------------------------------------
-static const uint8_t BREATH_LUT[64] = {
+// exp(sin) BREATH curve LUT — one full inhale/exhale cycle.
+// entry[i] = round( 255 * (exp(sin(2π·i/LUT_SIZE)) - e⁻¹) / (e − e⁻¹) ).
+// Asymmetric: exhale lingers at 0 (entries ~46..50 hold full black), inhale
+// ramps fast. That's what makes it read as "breathing" instead of "pulsing".
+static const uint8_t BREATH_LUT[LUT_SIZE] = {
    69,  80,  92, 105, 119, 134, 149, 165, 180, 195, 209, 221, 233, 242, 249, 253,
   255, 253, 249, 242, 233, 221, 209, 195, 180, 165, 149, 134, 119, 105,  92,  80,
    69,  58,  49,  41,  34,  28,  22,  18,  14,  10,   7,   5,   3,   2,   1,   0,
     0,   0,   1,   2,   3,   5,   7,  10,  14,  18,  22,  28,  34,  41,  49,  58,
 };
 
-// ---------------------------------------------------------------------------
-// Gaussian WAVE LUT — 64 entries covering 0..4σ. Each entry = round(255 *
-// exp(-(i/16)² / 2)). Visual width: at d=1σ the swell is ~61% peak; at 2σ
-// it's ~14%; at 3σ it's ~1%. With σ=4 LEDs on a 14-LED strip, the swell
-// occupies roughly the middle ⅓ of the strip at its visible width — broad,
-// soft, no hard edges. This is the "single broad swell" shape, not a blob.
-// ---------------------------------------------------------------------------
-static const uint8_t GAUSS_LUT[64] = {
+// Gaussian WAVE LUT — covers 0..4σ. entry[i] = round(255 * exp(-(i/16)² / 2)).
+// At 1σ ≈ 61% peak, at 2σ ≈ 14%, at 3σ ≈ 1%. With σ=4 LEDs on a 14-LED strip
+// the swell occupies the middle ~⅓ — soft, broad, no hard edges.
+static const uint8_t GAUSS_LUT[LUT_SIZE] = {
   255, 255, 253, 251, 247, 243, 238, 232, 225, 218, 210, 201, 192, 183, 174, 164,
   155, 145, 135, 126, 117, 108,  99,  91,  83,  75,  68,  61,  55,  49,  44,  39,
    35,  30,  27,  23,  20,  18,  15,  13,  11,  10,   8,   7,   6,   5,   4,   3,
@@ -118,30 +114,25 @@ static uint8_t   g_lastPwm[LED_COUNT];
 static bool      g_lastPwmInit       = false;
 
 // Interpolated lookup into BREATH_LUT. Returns 0..255. Linear interpolation
-// between adjacent entries removes the visible stair-step you'd otherwise
-// get at the slow 5.5 s breath period.
+// between entries removes stair-step on the slow 5.5 s breath period.
 static inline uint8_t breathQ(uint32_t phaseQ8) {
-  const uint8_t idx  = uint8_t((phaseQ8 >> 8) & 63u);
-  const uint8_t next = uint8_t((idx + 1) & 63u);
+  const uint8_t idx  = uint8_t((phaseQ8 >> 8) & LUT_MASK);
+  const uint8_t next = uint8_t((idx + 1)      & LUT_MASK);
   const uint8_t frac = uint8_t(phaseQ8 & 0xFFu);
   const int16_t v0 = BREATH_LUT[idx];
   const int16_t v1 = BREATH_LUT[next];
-  const int16_t v  = v0 + (((v1 - v0) * int16_t(frac)) >> 8);
-  return uint8_t(v);
+  return uint8_t(v0 + (((v1 - v0) * int16_t(frac)) >> 8));
 }
 
-// Gaussian lookup. dist_q8 is unsigned Q8 LED-units. The LUT covers 0..4σ in
-// 64 entries → each entry covers σ/16 Q8 units = WAVE_SIGMA_LEDS_Q8/16 = 64,
-// so index = dist_q8 / 64 = dist_q8 >> 6. (Hard-coded for σ=4 LEDs; if you
-// change WAVE_SIGMA_LEDS_Q8, retune the >>6.)
+// Gaussian lookup. dist_q8 is unsigned Q8 LED-units. The LUT covers 0..4σ
+// in LUT_SIZE entries. See GAUSS_LUT_SHIFT comment for the index derivation.
 static inline uint8_t gaussQ(uint16_t dist_q8) {
   static_assert(WAVE_SIGMA_LEDS_Q8 == 4 * 256,
-                "GAUSS_LUT step assumes σ = 4 LEDs (1024 Q8); retune the >>6");
-  uint16_t idx = dist_q8 >> 6;
-  if (idx > 63) return 0;
-  // Linear-interp between adjacent gauss LUT entries for sub-quantum smoothness.
-  const uint8_t next = (idx >= 63) ? 63 : uint8_t(idx + 1);
-  const uint8_t frac = uint8_t(dist_q8 & 0x3F) << 2;  // 0..63 → 0..252 (Q8 frac)
+                "GAUSS_LUT step assumes σ = 4 LEDs (1024 Q8); retune GAUSS_LUT_SHIFT");
+  uint16_t idx = dist_q8 >> GAUSS_LUT_SHIFT;
+  if (idx >= LUT_SIZE) return 0;
+  const uint8_t next = (idx >= LUT_SIZE - 1) ? LUT_SIZE - 1 : uint8_t(idx + 1);
+  const uint8_t frac = uint8_t(dist_q8 & ((1u << GAUSS_LUT_SHIFT) - 1)) << GAUSS_FRAC_LSHIFT;
   const int16_t g0 = GAUSS_LUT[idx];
   const int16_t g1 = GAUSS_LUT[next];
   return uint8_t(g0 + (((g1 - g0) * int16_t(frac)) >> 8));
@@ -195,12 +186,11 @@ void ledSetMode(LedMode m) {
 // scale* space. Crossfade blending and baseLevel scaling happen in ledRender.
 
 static void renderBreathRaw(uint32_t now, uint8_t out[LED_COUNT]) {
-  // Reduce now mod period BEFORE the *64*256 multiply so the intermediate
-  // result stays bounded in uint32_t (otherwise wraps every ~262 s and the
-  // curve glitches at each wrap).
+  // Reduce now mod period BEFORE the LUT_SIZE*256 multiply so the intermediate
+  // stays bounded in uint32_t (otherwise wraps ~262 s and the curve glitches).
   const uint16_t period = cfg.ledBreathPeriodMs ? cfg.ledBreathPeriodMs : 1;
   const uint32_t t       = uint32_t(now) % period;
-  const uint32_t phaseQ8 = (t * 64u * 256u) / period;
+  const uint32_t phaseQ8 = (t * LUT_SIZE * 256u) / period;
   const uint8_t  curve   = breathQ(phaseQ8);  // 0..255 — full-range LUT
   // Map the 0..255 curve onto [ledBreathLow .. ledBreathPeak]. The peak
   // keeps idle dim regardless of baseLevel; the low value floors the

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -89,7 +89,7 @@ static bool      g_lastPwmInit       = false;
 
 // Interpolated lookup into BREATH_LUT. Returns 0..255. Linear interpolation
 // between entries removes stair-step on the slow 5.5 s breath period.
-static inline uint8_t breathQ(uint32_t phaseQ8) {
+static inline uint8_t breathValue(uint32_t phaseQ8) {
   const uint8_t idx  = uint8_t((phaseQ8 >> 8) & LUT_MASK);
   const uint8_t next = uint8_t((idx + 1)      & LUT_MASK);
   const uint8_t frac = uint8_t(phaseQ8 & 0xFFu);
@@ -100,7 +100,7 @@ static inline uint8_t breathQ(uint32_t phaseQ8) {
 
 // Gaussian lookup. dist_q8 is unsigned Q8 LED-units. The LUT covers 0..4σ
 // in LUT_SIZE entries. See GAUSS_LUT_SHIFT comment for the index derivation.
-static inline uint8_t gaussQ(uint16_t dist_q8) {
+static inline uint8_t gaussValue(uint16_t dist_q8) {
   static_assert(WAVE_SIGMA_LEDS_Q8 == 4 * 256,
                 "GAUSS_LUT step assumes σ = 4 LEDs (1024 Q8); retune GAUSS_LUT_SHIFT");
   uint16_t idx = dist_q8 >> GAUSS_LUT_SHIFT;
@@ -165,7 +165,7 @@ static void renderBreathRaw(uint32_t now, uint8_t out[LED_COUNT]) {
   const uint16_t period = cfg.ledBreathPeriodMs ? cfg.ledBreathPeriodMs : 1;
   const uint32_t t       = uint32_t(now) % period;
   const uint32_t phaseQ8 = (t * LUT_SIZE * 256u) / period;
-  const uint8_t  curve   = breathQ(phaseQ8);  // 0..255 — full-range LUT
+  const uint8_t  curve   = breathValue(phaseQ8);  // 0..255 — full-range LUT
   // Map the 0..255 curve onto [ledBreathLow .. ledBreathPeak]. The peak
   // keeps idle dim regardless of baseLevel; the low value floors the
   // exhale (default 0 = full black on exhale, original behavior).
@@ -189,25 +189,24 @@ static void renderBreathRaw(uint32_t now, uint8_t out[LED_COUNT]) {
 // swell and the mist modulation are guaranteed phase-locked off the same
 // `now` — the mist you feel is literally the wave you see.
 static inline int32_t waveCenterYQ8(uint32_t now) {
-  const int32_t span_q8 = int32_t(LED_COUNT) * 256
+  const int32_t spanQ8 = int32_t(LED_COUNT) * 256
                         + int32_t(WAVE_TRAVEL_PAD_Q8) * 2;
   const uint16_t period = cfg.wavePeriodMs ? cfg.wavePeriodMs : 1;
   const uint32_t t = uint32_t(now) % period;
   return int32_t(LED_COUNT) * 256 + int32_t(WAVE_TRAVEL_PAD_Q8)
-       - int32_t((uint64_t(span_q8) * t) / period);
+       - int32_t((uint64_t(spanQ8) * t) / period);
 }
 
 static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
-  const int32_t y_q8 = waveCenterYQ8(now);
+  const int32_t waveCenterQ8 = waveCenterYQ8(now);
   for (uint8_t i = 0; i < LED_COUNT; ++i) {
-    const int32_t led_q8 = int32_t(i) * 256;
-    int32_t       d_q8   = led_q8 - y_q8;
-    if (d_q8 < 0) d_q8 = -d_q8;
-    const uint8_t g      = (d_q8 > 0xFFFF) ? 0 : gaussQ(uint16_t(d_q8));
-    // base + (peak * gauss / 255), clamped just in case constants overflow
-    // the 8-bit sum after retuning.
+    const int32_t ledPosQ8 = int32_t(i) * 256;
+    int32_t       distQ8   = ledPosQ8 - waveCenterQ8;
+    if (distQ8 < 0) distQ8 = -distQ8;
+    const uint8_t gauss    = (distQ8 > 0xFFFF) ? 0 : gaussValue(uint16_t(distQ8));
+    // base + (peak * gauss / 255), clamped in case retuning overflows the sum.
     uint16_t v = uint16_t(cfg.waveBaseLevel)
-               + ((uint16_t(cfg.waveSwellPeak) * uint16_t(g)) >> 8);
+               + ((uint16_t(cfg.waveSwellPeak) * uint16_t(gauss)) >> 8);
     if (v > 255) v = 255;
     out[i] = uint8_t(v);
   }
@@ -226,12 +225,12 @@ static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
 // back down with the wave as it exits off-screen above. That timing is
 // the whole point of evaluating here instead of at index 0.
 uint8_t waveIntensityAtPiezo(uint32_t now) {
-  const int32_t y_q8     = waveCenterYQ8(now);
-  const int32_t piezo_q8 = -int32_t(MIST_PIEZO_OFFSET_LEDS_Q8);  // above i=0
-  int32_t       d_q8     = piezo_q8 - y_q8;
-  if (d_q8 < 0) d_q8 = -d_q8;
-  if (d_q8 > 0xFFFF) return 0;
-  return gaussQ(uint16_t(d_q8));
+  const int32_t waveCenterQ8 = waveCenterYQ8(now);
+  const int32_t piezoPosQ8   = -int32_t(MIST_PIEZO_OFFSET_LEDS_Q8);  // above i=0
+  int32_t       distQ8       = piezoPosQ8 - waveCenterQ8;
+  if (distQ8 < 0) distQ8 = -distQ8;
+  if (distQ8 > 0xFFFF) return 0;
+  return gaussValue(uint16_t(distQ8));
 }
 
 static inline void renderRaw(LedMode m, uint32_t now, uint8_t out[LED_COUNT]) {

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -131,6 +131,9 @@ void ledInit() {
 
 // Push a per-LED final frame to the chip, skipping any LED whose cached value
 // already matches. Inputs are already gamma-corrected.
+// Hardware quirk: the 14 populated LEDs are on Matrix B (CB1/CB2) — must use
+// setLEDPWM(lednum, pwm, 0); drawPixel(x,y,…) writes Matrix A which is
+// unpopulated on this board and would silently no-op.
 static void writePerLed(const uint8_t pwm[LED_COUNT]) {
   if (!g_lastPwmInit) return;
   for (uint8_t i = 0; i < LED_COUNT; ++i) {

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -218,7 +218,7 @@ static void renderWaveRaw(uint32_t now, uint8_t out[LED_COUNT]) {
 // the swell is centered at the piezo, returns 255 (mist crest); when far
 // away, returns 0 (mist trough). The main loop multiplies this through
 // g_currentLevel + the cfg.mistWaveTroughQ8 floor to produce the actual
-// mist drive level — see `computeMistOutLevel()` in BlockKit_Test.ino.
+// mist drive level — see `mistOutLevel()` in BlockKit_Production.ino.
 //
 // Because the piezo is physically above the top LED, the gaussian peaks at
 // the piezo *after* the LED at index 0 has already peaked — so the mist

--- a/variants/block-kit/firmware/BlockKit_Production/mist.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/mist.ino
@@ -34,8 +34,7 @@ static inline uint8_t levelToDuty(uint8_t level) {
   return uint8_t(scaled < cfg.mistDutyMin ? cfg.mistDutyMin : scaled);
 }
 
-// Update mist output based on the current smoothed level. Called once per
-// main-loop iteration. No-op while inhibited (post hard-stop until re-enabled).
+// No-op while inhibited (post hard-stop until mistEnable(true)).
 void mistApply(uint8_t level) {
   if (g_mistInhibited) return;
 
@@ -59,11 +58,7 @@ void mistApply(uint8_t level) {
   ledcWrite(PIN_MIST_PWM, levelToDuty(level));
 }
 
-// Immediately stop mist regardless of the smoother — used on container lift
-// for safety. Also locks mistApply() as a no-op until mistEnable(true) is
-// called, so the LED ring's gradual fade-down doesn't re-engage the boost.
-// Idempotent: if mist was already off we just (re)assert the inhibit flag
-// without churning the pins.
+// Cut PWM + boost rail and lock mistApply() until mistEnable(true). Idempotent.
 void mistHardStop() {
   if (g_mistBoostOn) {
     ledcWrite(PIN_MIST_PWM, 0);
@@ -75,8 +70,6 @@ void mistHardStop() {
   g_mistInhibited = true;
 }
 
-// Re-arm the mist path so the next mistApply(level>0) can engage the boost.
-// Called by the main loop when entering RUNNING.
 void mistEnable(bool enabled) {
   if (enabled) g_mistInhibited = false;
   else         mistHardStop();

--- a/variants/block-kit/firmware/BlockKit_Production/mist.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/mist.ino
@@ -1,15 +1,10 @@
 // Mist drive — 108.7 kHz PWM on D0, gated by D3 boost enable.
 //
-// The main loop calls mistApply(level) every iteration with the smoothed
-// `g_currentLevel`. Level 0 means fully off; the function handles boost-rail
-// gating automatically:
-//   - level > 0 and boost OFF -> turn boost ON, settle 500 µs, then PWM
-//   - level > 0 -> update PWM duty proportionally (level 255 = cfg.mistDutyMax)
-//   - level == 0 and boost ON -> PWM 0, force D0 LOW, drop boost
-// On a real "container lifted" event the main loop calls mistHardStop() which
-// immediately cuts PWM and the boost rail regardless of smoother state — the
-// LED ring keeps fading via the smoother but mist stops the moment the reed
-// opens (safety: no surprise misting after the bottle is gone).
+// mistApply(level) gates the 5 V boost rail automatically:
+//   level 0 + boost ON  → PWM 0, D0 LOW, boost OFF.
+//   level > 0 + boost OFF → boost ON, 500 µs settle, then PWM.
+//   level > 0 + boost ON  → update duty (level 255 = cfg.mistDutyMax).
+// mistHardStop() bypasses the smoother for safety (container lift, OTA).
 
 #include "pins.h"
 #include "config.h"

--- a/variants/block-kit/firmware/BlockKit_Production/status_led.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/status_led.ino
@@ -1,8 +1,4 @@
-// D7 white LED — simple "waiting" indicator.
-//
-// On when no container is docked (dim, ~10 % brightness). Off the moment the
-// container is dropped onto the dock (the 14-LED ring takes over the user's
-// attention). No breathing, no fade — a single LED doesn't need ceremony.
+// D7 white LED — "waiting" indicator. Dim when no container; off when docked.
 
 #include "pins.h"
 #include "config.h"

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -1,7 +1,5 @@
 // Synchronous HTTP server backing the single-page web UI.
-//
-// Routes (full list in plan; auth model: GET endpoints open, POST endpoints
-// gated by HTTP Basic against the admin password hash):
+// GETs are open; POSTs require HTTP Basic against the admin password hash.
 //
 //   GET  /                  index page (PROGMEM HTML)
 //   GET  /api/status        live status JSON
@@ -15,12 +13,6 @@
 //   GET  /api/events        Server-Sent Events stream (status every 250 ms)
 //   GET  /api/log           recent log lines (plain text)
 //   GET  /api/info          device info (mac, ip, ver, mDNS) — JSON
-//
-// The synchronous WebServer fits our cooperative loop just fine: handleClient()
-// returns in microseconds when there's no client, and serves ~12 KB HTML in
-// a few ms even on slow WiFi. The SSE stream is special — we keep one client
-// fd open and write a `data: {...}\n\n` line every SSE_INTERVAL_MS from the
-// main loop's webHandle() tick.
 
 #include <WebServer.h>
 #include <WiFi.h>

--- a/variants/block-kit/firmware/BlockKit_Production/wifi_setup.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/wifi_setup.ino
@@ -1,20 +1,7 @@
-// WiFi onboarding via tzapu's WiFiManager — the de-facto ESP32 captive-portal
-// helper. On boot: if NVS has saved credentials, autoConnect() joins them as
-// STA. If not (first boot) or the saved AP is gone, autoConnect() spins up
-// "BlockKit-Setup-XXXX" as a WPA2 AP (password `blockkit-setup`), runs a
-// captive portal, lets the user pick a network + supply credentials + set
-// the admin password, then reboots into STA.
-//
-// Why WiFiManager and not a hand-rolled DNS + WebServer captive portal:
-// the captive-portal path has a long list of OS-specific quirks (iOS probe
-// at /hotspot-detect.html, Android at /generate_204, Windows at NCSI) and
-// WiFiManager already handles them all. We pay one dep for "less stuff to
-// debug" — exactly the trade David asked for.
-//
-// During the portal phase: the LED ring renders a slow alternating-half
-// pattern via the existing BREATH/WAVE mode so the user has a clear visual
-// "I'm waiting for input". After STA is up the normal state machine takes
-// over.
+// WiFi onboarding via tzapu's WiFiManager.
+// On boot: autoConnect() joins saved STA; on first boot or gone-AP it spins
+// up "BlockKit-Setup-XXXX" (WPA2, pwd `blockkit-setup`) as a captive portal.
+// WiFiManager handles iOS/Android/Windows captive-portal probes for us.
 
 #include <WiFi.h>
 #include <WiFiManager.h>


### PR DESCRIPTION
## Summary

Cleans up the Block Kit production firmware for readability while preserving every feature. The codebase shrinks ~140 LOC (-25% on the main sketch) by consolidating duplicate logic, trimming long comment blocks, and renaming cryptic identifiers. All load-bearing hardware comments (piezo resonance, ESP32-C6 ADC quirk, USB-CDC delay, OTA safety, wave-mist sync, Matrix-B addressing) are preserved.

### What changed

- **rampToward() helper** — unified `smoothLevel()` + `smoothLedScale()` into one pure asymmetric ramp helper. No behavior change.
- **Named constants** — `LUT_SIZE`, `LUT_MASK`, `GAUSS_LUT_SHIFT`, `GAUSS_FRAC_LSHIFT` replace bare 64 / 0x3F / shift-6 / shift-2 in the LUT math. `static_assert` still guards the sigma=4 LED invariant.
- **Trimmed file headers** — BlockKit_Production.ino 66 to 15 lines, led_driver.ino 32 to 5, mist.ino 12 to 7, web_server.ino 23 to 14, wifi_setup.ino 17 to 4. API route list kept; wave-mist sync physics kept; all safety + hardware-quirk comments kept.
- **Deleted tautological comments** — restated-the-code comments removed in button.ino, status_led.ino, mist.ino.
- **Extracted nvsPutString helper** — eliminates 9 lines of repeated Preferences open/put/close scaffolding across the 3 secret setters. NVS keys + values unchanged.
- **Renames for clarity**:
  - `g_dimDir` to `g_levelAdjustDir`, `g_fastFadeUp` to `g_fastLevelUp`, `g_lastStatMs` to `g_lastStatPrintMs`
  - `computeMistOutLevel()` to `mistOutLevel()` (drop `compute` prefix on pure functions)
  - `rampUserLevel()` to `rampLevel()`, `parseTail()` to `parseNumberArg()`, `statTick()` to `statusTick()`
  - button.ino: g_lastRaw/g_debounced/g_longActive/g_btnLastTickMs to g_buttonLastRaw/g_buttonState/g_inLongPress/g_longPressTickMs
  - current_sense.ino: g_widx/g_sum/g_sumSq/g_filled to g_windowWriteIdx/g_windowSum/g_windowSumSquares/g_windowFilled
  - led_driver.ino: `breathQ`/`gaussQ` to `breathValue`/`gaussValue`; render locals y_q8/d_q8/g to waveCenterQ8/distQ8/gauss
- **ARCHITECTURE.md** synced with the new names.
- **Matrix-B addressing note** restored above `writePerLed()` (Codex review caught the over-trim).

### Verification

- `arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32C6` clean throughout. 0 warnings, 0 errors.
- Flash: 1244670 bytes (94%) — unchanged from baseline.
- RAM: 64252 bytes (19%) — unchanged from baseline.
- NVS binary layout: verified unchanged (Codex review). Existing user configs will not be lost.
- Logic of unified rampToward() helper: bit-for-bit equivalent to the old smoothers (Codex review).

## Test plan

- [x] `arduino-cli compile` passes with zero new warnings
- [x] Codex review (`/codex:review`) — 1 finding addressed (Matrix-B note restored)
- [x] Built-in `/review` final pass — clean
- [ ] **Hardware smoke test** (run before merge): power on -> IDLE breath -> dock -> RUNNING wave + mist -> short-press LED hide/show -> long-press level ramp -> lift -> mist hard-stops, dim fade -> web UI loads -> OTA upload hard-stops mist
- [ ] Verify NVS persistence: change a setting via web UI, reboot, confirm value persists

Generated with [Claude Code](https://claude.com/claude-code)
