### PR TITLE
Rebrand to mistmaker.local + 2-tile UI redesign + live controls

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -429,6 +429,29 @@ bool     appLedsHidden()      { return g_ledsHidden; }
 static bool g_kickLedWalk = false;
 void appKickLedWalk()         { g_kickLedWalk = true; }
 
+// Status-LED override (-1 = auto, 0 = force off, 1 = force on). Used by the
+// web UI manual override; auto restores the "reflect container presence" rule.
+static int8_t g_statusLedOverride = -1;
+void    appSetStatusLedOverride(int8_t v) { g_statusLedOverride = v; }
+int8_t  appStatusLedOverride()            { return g_statusLedOverride; }
+
+// Live user-level setter — mirrors the serial 'v' command. Skips applying
+// during TRANSITION_FROM_RUNNING so the fade-out cinematic isn't interrupted.
+void appSetLevel(uint8_t level) {
+  g_userLevel = level;
+  if (g_state != AppState::TRANSITION_FROM_RUNNING) {
+    g_targetLevel = g_userLevel;
+  }
+}
+
+// Manual state override for testing without a magnet. Reuses the same
+// entry transitions the reed event handler does. A subsequent real reed
+// edge will resync to physical truth.
+void appForceState(AppState s) {
+  if (s == AppState::RUNNING)      enterRunning();
+  else if (s == AppState::IDLE)    enterIdle();
+}
+
 // ----------------------------------------------------------------------
 // Arduino entry points
 // ----------------------------------------------------------------------
@@ -518,11 +541,11 @@ void loop() {
   onContainerEvent(containerPoll());
   onButtonEvent(buttonPoll());
 
-  // D7 reflects container presence directly — dim when waiting for a dock,
-  // off when something is docked. Independent of mist on/off and LED ring
-  // state so the indicator stays a stable "is the device looking for input?"
-  // signal.
-  statusLedSet(!containerIsPresent());
+  // D7 reflects container presence directly (dim when waiting for a dock,
+  // off when docked) unless a web-UI override forces a specific state.
+  if (g_statusLedOverride == 0)      statusLedSet(false);
+  else if (g_statusLedOverride == 1) statusLedSet(true);
+  else                               statusLedSet(!containerIsPresent());
 
   currentSenseLogPlot(uint8_t(g_state));
   statusTick();

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -73,7 +73,7 @@ void configResetDefaults() {
   cfg.reedRemoveDwellMs       = CFG_DEFAULT_REED_REMOVE_DWELL_MS;
   cfg.statusLedDimDuty        = CFG_DEFAULT_STATUS_LED_DIM_DUTY;
   // Identity + secrets default to empty — first-boot setup populates them.
-  strncpy(cfg.hostname, "blockkit", CFG_HOSTNAME_MAX);
+  strncpy(cfg.hostname, "mistmaker", CFG_HOSTNAME_MAX);
   cfg.hostname[CFG_HOSTNAME_MAX] = '\0';
   cfg.adminPasswordHash[0] = '\0';
   cfg.otaPassword[0] = '\0';
@@ -175,7 +175,7 @@ void configInit() {
   }
 
   // 2. Identity + secrets.
-  const String host  = p.getString(KEY_HOST, "blockkit");
+  const String host  = p.getString(KEY_HOST, "mistmaker");
   const String admin = p.getString(KEY_ADMIN_PW, "");
   const String ota   = p.getString(KEY_OTA_PW,   "");
   strncpy(cfg.hostname,           host.c_str(),  CFG_HOSTNAME_MAX);

--- a/variants/block-kit/firmware/BlockKit_Production/ota.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/ota.ino
@@ -1,5 +1,5 @@
 // ArduinoOTA wiring. Once STA is up the Arduino IDE auto-discovers the
-// device as a network port (`Tools → Port → blockkit at 192.168.x.x (esp32)`)
+// device as a network port (`Tools → Port → mistmaker at 192.168.x.x (esp32)`)
 // — pick it, hit Upload, the IDE prompts for the password set in the WiFi
 // captive portal. Password mismatch silently rejects, just like Arduino OTA
 // always does.

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -6,7 +6,12 @@
 //   GET  /api/config        cfg snapshot (NEVER includes secrets)
 //   POST /api/config        apply + save fields; body = {"field":"name","value":N}
 //   POST /api/cmd/walk      run ledWalk on next loop
+//   POST /api/cmd/leds      toggle hide/show LED ring (mist unaffected)
 //   POST /api/cmd/scope     toggle scope mode
+//   POST /api/cmd/plotmute  toggle [PLOT] CSV stream mute
+//   POST /api/cmd/level     set runtime userLevel; body = {"value":0..255}
+//   POST /api/cmd/state     force state idle/running; body = {"state":"..."}
+//   POST /api/cmd/statled   override indicator LED; body = {"mode":"auto|on|off"}
 //   POST /api/cmd/reboot    ESP.restart() after 250 ms
 //   POST /api/cmd/forget    wipe WiFi creds + reboot into captive portal
 //   POST /api/cmd/password  set new admin password; body = {"new":"..."}
@@ -28,12 +33,17 @@ extern uint8_t  appCurrentLevel();
 extern void     appKickLedWalk();
 extern bool     appLedsHidden();
 extern void     appToggleLedsHidden();
+extern void     appSetLevel(uint8_t);
+extern void     appForceState(AppState);
+extern void     appSetStatusLedOverride(int8_t);
+extern int8_t   appStatusLedOverride();
 extern bool     containerIsPresent();
 extern bool     containerRawPresent();
 extern bool     mistIsRunning();
 extern float    currentMeanMa();
 extern float    currentVarMa2();
 extern void     currentSenseToggleScope();
+extern void     currentSenseTogglePlotMute();
 extern void     wifiForgetAndReboot();
 extern bool     wifiIsSetupMode();
 extern size_t   logSnapshot(char*, size_t);
@@ -127,7 +137,8 @@ static size_t buildStatusJson(char* out, size_t cap) {
     "\"varMa2\":%.1f,"
     "\"uptimeMs\":%lu,"
     "\"freeHeap\":%u,"
-    "\"rssi\":%d}",
+    "\"rssi\":%d,"
+    "\"statLedOverride\":%d}",
     webStateName(appCurrentState()),
     unsigned(appCurrentState()),
     digitalRead(PIN_BUTTON),
@@ -142,7 +153,8 @@ static size_t buildStatusJson(char* out, size_t cap) {
     currentVarMa2(),
     (unsigned long)millis(),
     unsigned(ESP.getFreeHeap()),
-    (int)WiFi.RSSI());
+    (int)WiFi.RSSI(),
+    int(appStatusLedOverride()));
 }
 
 // --------------------------------------------------------------------------
@@ -284,6 +296,63 @@ static void handleCmdScope() {
   g_http.send(200, "application/json", "{\"ok\":true}");
 }
 
+static void handleCmdPlotMute() {
+  if (!requireAuth()) return;
+  currentSenseTogglePlotMute();
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// Live level set — mirrors serial 'vN'. Body: {"value": 0..255}.
+static void handleCmdLevel() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  long v = 0;
+  if (!jsonGetLong(body, "value", v) || v < 0 || v > 255) {
+    g_http.send(400, "application/json", "{\"error\":\"value must be 0..255\"}");
+    return;
+  }
+  appSetLevel(uint8_t(v));
+  Serial.printf("[WEB] level=%ld\n", v);
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// Manual reed-state override. Body: {"state":"idle"|"running"}.
+static void handleCmdState() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  char state[16];
+  if (!jsonGetString(body, "state", state, sizeof(state))) {
+    g_http.send(400, "application/json", "{\"error\":\"missing 'state'\"}");
+    return;
+  }
+  if (strcmp(state, "idle") == 0)         appForceState(AppState::IDLE);
+  else if (strcmp(state, "running") == 0) appForceState(AppState::RUNNING);
+  else {
+    g_http.send(400, "application/json", "{\"error\":\"state must be 'idle' or 'running'\"}");
+    return;
+  }
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// Indicator-LED override. Body: {"mode":"auto"|"on"|"off"}.
+static void handleCmdStatLed() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  char mode[8];
+  if (!jsonGetString(body, "mode", mode, sizeof(mode))) {
+    g_http.send(400, "application/json", "{\"error\":\"missing 'mode'\"}");
+    return;
+  }
+  if      (strcmp(mode, "auto") == 0) appSetStatusLedOverride(-1);
+  else if (strcmp(mode, "on")   == 0) appSetStatusLedOverride(1);
+  else if (strcmp(mode, "off")  == 0) appSetStatusLedOverride(0);
+  else {
+    g_http.send(400, "application/json", "{\"error\":\"mode must be auto|on|off\"}");
+    return;
+  }
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
 static void handleCmdReboot() {
   if (!requireAuth()) return;
   g_http.send(200, "application/json", "{\"ok\":true,\"rebooting\":250}");
@@ -381,6 +450,10 @@ void webInit() {
   g_http.on("/api/cmd/walk",        HTTP_POST, handleCmdWalk);
   g_http.on("/api/cmd/leds",        HTTP_POST, handleCmdLeds);
   g_http.on("/api/cmd/scope",       HTTP_POST, handleCmdScope);
+  g_http.on("/api/cmd/plotmute",    HTTP_POST, handleCmdPlotMute);
+  g_http.on("/api/cmd/level",       HTTP_POST, handleCmdLevel);
+  g_http.on("/api/cmd/state",       HTTP_POST, handleCmdState);
+  g_http.on("/api/cmd/statled",     HTTP_POST, handleCmdStatLed);
   g_http.on("/api/cmd/reboot",      HTTP_POST, handleCmdReboot);
   g_http.on("/api/cmd/forget",      HTTP_POST, handleCmdForget);
   g_http.on("/api/cmd/password",    HTTP_POST, handleCmdPassword);

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -1,10 +1,10 @@
-// Single-page web UI for the Block Kit, embedded as one PROGMEM string.
+// Single-page web UI for the Mist Maker, embedded as one PROGMEM string.
 // Vanilla HTML/CSS/JS — no external CDN, no LittleFS — so the UI loads with
 // just one HTTP roundtrip and works offline on the LAN.
 //
-// Tabs: Status (live cards + sparkline), Config (sliders for every cfg.*
-// field, save-gated by admin password), Debug (raw IO + commands), About
-// (device info + OTA hint).
+// Tabs: Status (quick-control tiles + live cards + sparkline), Config
+// (advanced sliders collapsed by default), Debug (commands + log), About
+// (device info + admin password).
 //
 // Update strategy: SSE subscription via EventSource('/api/events') drives
 // the Status + Debug tabs at 4 Hz; Config does a one-shot GET on tab show
@@ -20,7 +20,7 @@ const char INDEX_HTML[] PROGMEM = R"==(<!doctype html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="color-scheme" content="dark">
 <meta name="theme-color" content="#0c0d10">
-<title>Block Kit</title>
+<title>Mist Maker</title>
 <style>
 :root{
   --bg:#0c0d10; --fg:#e7eaee; --mut:#8a93a1; --line:#1d2128;
@@ -93,6 +93,37 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
 .kv b{color:var(--fg);font-weight:500}
 .setup-banner{background:#3a2a14;color:var(--warn);border:1px solid var(--warn);
   padding:10px 14px;border-radius:var(--r);margin-bottom:12px}
+/* Quick-control tiles (Status tab) */
+.tile-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin:8px 0 14px}
+.tile{background:var(--card);border:1px solid var(--line);border-radius:var(--r);padding:14px}
+.tile h3{margin:0 0 8px;font-size:.9em;color:var(--mut);text-transform:uppercase;letter-spacing:.5px;font-weight:500;
+  display:flex;align-items:center;justify-content:space-between;gap:8px}
+.tile .pct{font-size:clamp(22px,3vw,30px);font-weight:600;margin:2px 0 6px}
+.tile .sub{color:var(--mut);font-size:.85em;margin-bottom:10px}
+.tile input[type=range]{width:100%;margin:6px 0 0}
+/* Toggle switch */
+.sw{position:relative;width:42px;height:24px;background:#2a2e36;border-radius:12px;cursor:pointer;flex-shrink:0;
+  transition:background .15s;border:0;padding:0}
+.sw.on{background:var(--accent)}
+.sw::after{content:"";position:absolute;top:2px;left:2px;width:20px;height:20px;background:#fff;border-radius:50%;
+  transition:left .15s}
+.sw.on::after{left:20px}
+/* Status pills + override row */
+.pills{display:flex;flex-wrap:wrap;gap:10px 14px;align-items:center;margin:8px 0 12px;color:var(--mut);font-size:.9em}
+.pills .grp{display:flex;align-items:center;gap:6px;background:var(--card);border:1px solid var(--line);
+  border-radius:999px;padding:4px 10px 4px 12px}
+.pills .grp .name{font-size:.85em;text-transform:uppercase;letter-spacing:.5px}
+.pills .grp .val{color:var(--fg);font-weight:500}
+.btn.mini{padding:3px 9px;font-size:.82em;border-radius:8px}
+.btn.mini.active{background:var(--accent);color:#0c0d10;border-color:transparent}
+/* Advanced settings collapse */
+details.adv{margin:12px 0;border:1px solid var(--line);border-radius:var(--r);
+  background:var(--card);padding:0}
+details.adv>summary{padding:12px 14px;cursor:pointer;color:var(--mut);
+  text-transform:uppercase;letter-spacing:.5px;font-size:.85em;font-weight:500;list-style:none}
+details.adv>summary::after{content:" \25be";color:var(--mut)}
+details.adv[open]>summary::after{content:" \25b4"}
+details.adv>div{padding:0 14px 14px}
 @media(max-width:560px){
   .field{grid-template-columns:1fr 1fr;}
   .field .hint{grid-column:1/-1}
@@ -101,7 +132,7 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
 </head>
 <body>
 <header>
-  <h1>Block Kit</h1>
+  <h1>Mist Maker</h1>
   <span class="meta">
     <span id="connDot" class="dot"></span>
     <span id="connTxt">connecting…</span> ·
@@ -123,14 +154,62 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
     Device is in WiFi setup mode. Join the
     <code>MistMaker-Setup-XXXX</code> AP (password <code>mistmaker-setup</code>).
   </div>
+
+  <!-- Quick-control tiles: mist + LED wave -->
+  <div class="tile-grid">
+    <div class="tile" id="tileMist">
+      <h3>Mist <button class="sw" id="swMist" aria-label="mist toggle"></button></h3>
+      <div class="pct"><span id="mistPct">-</span>%</div>
+      <div class="sub" id="mistSub">-</div>
+      <input type="range" min="0" max="100" step="1" id="mistSlider" value="0">
+    </div>
+    <div class="tile" id="tileWave">
+      <h3>LED Wave <button class="sw" id="swWave" aria-label="wave toggle"></button></h3>
+      <div class="pct"><span id="wavePct">-</span>%</div>
+      <div class="sub" id="waveSub">-</div>
+      <input type="range" min="0" max="100" step="1" id="waveSlider" value="0">
+    </div>
+  </div>
+
+  <!-- Hardware status + manual override pills -->
+  <div class="pills">
+    <div class="grp"><span class="name">Reed</span>
+      <span class="val" id="pReed">-</span>
+      <button class="btn mini ghost" id="bForceRun">Force RUNNING</button>
+      <button class="btn mini ghost" id="bForceIdle">Force IDLE</button>
+    </div>
+    <div class="grp"><span class="name">Indicator LED</span>
+      <span class="val" id="pStat">-</span>
+      <button class="btn mini ghost" id="bStLAuto">Auto</button>
+      <button class="btn mini ghost" id="bStLOn">On</button>
+      <button class="btn mini ghost" id="bStLOff">Off</button>
+    </div>
+  </div>
+
+  <!-- Mist pulse depth (friendly wrapper around cfg.mistWaveTroughQ8) -->
+  <details class="adv" id="quickPulse"><summary>Mist pulse depth (how visible is the breathing)</summary>
+    <div>
+      <p style="color:var(--mut);font-size:.9em;margin:8px 0">
+        0% = mist runs steady. 100% = mist swings full range with the LED wave.
+        Default ~64% (matches the LED wave's own visible range).
+      </p>
+      <div class="field" style="grid-template-columns:1fr 90px">
+        <input type="range" min="0" max="100" step="1" id="pulseSlider" value="64">
+        <input type="number" min="0" max="100" step="1" id="pulseNum" value="64">
+      </div>
+      <div class="actions"><button class="btn" id="bPulseSave">Save pulse depth</button></div>
+    </div>
+  </details>
+
+  <!-- Compact live row + sparkline + weather (weather hidden until configured) -->
+  <h2>Live</h2>
   <div class="cards">
     <div class="card" id="cState"><div class="lbl">State</div><div class="v" id="vState">-</div></div>
-    <div class="card" id="cMist"><div class="lbl">Mist</div><div class="v" id="vMist">-</div></div>
     <div class="card" id="cCur"><div class="lbl">Current</div><div class="v"><span id="vCurMa">-</span> mA</div></div>
     <div class="card" id="cUp"><div class="lbl">Uptime</div><div class="v" id="vUp">-</div></div>
+    <div class="card" id="cWx" hidden><div class="lbl">Outdoor</div><div class="v"><span id="vWxT">-</span>&deg;C / <span id="vWxH">-</span>%</div></div>
   </div>
-  <h2>Live</h2>
-  <div class="row">
+  <div class="row" style="margin-top:8px">
     <span>Button raw <b id="vBtn">-</b></span>
     <span>Reed raw <b id="vReed">-</b></span>
     <span>User level <b id="vUl">-</b></span>
@@ -144,14 +223,20 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
 </section>
 
 <section id="config" hidden>
-  <p style="color:var(--mut)">Move a slider or type a value, then <b>Save &amp; Apply</b>.
-  Saving prompts for the admin password (set during WiFi setup).</p>
-  <div id="cfgForm"></div>
-  <div class="actions">
-    <button class="btn" id="btnSave">Save &amp; Apply</button>
-    <button class="btn ghost" id="btnRevert">Revert</button>
-    <button class="btn ghost" id="btnDefaults">Reset to defaults</button>
-  </div>
+  <p style="color:var(--mut)">Most users will only need the Status tab. The
+  settings below are fine-tuning knobs (kept collapsed by default). Move a
+  slider, then <b>Save &amp; Apply</b>. Saving prompts for the admin password
+  set during WiFi setup.</p>
+  <details class="adv" open><summary>Advanced settings</summary>
+    <div>
+      <div id="cfgForm"></div>
+      <div class="actions">
+        <button class="btn" id="btnSave">Save &amp; Apply</button>
+        <button class="btn ghost" id="btnRevert">Revert</button>
+        <button class="btn ghost" id="btnDefaults">Reset to defaults</button>
+      </div>
+    </div>
+  </details>
 </section>
 
 <section id="debug" hidden>
@@ -165,12 +250,22 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
   </div>
   <h2>Commands</h2>
   <div class="actions">
-    <button class="btn ghost" id="btnWalk">LED walk</button>
-    <button class="btn ghost" id="btnLeds">Hide / show LEDs</button>
-    <button class="btn ghost" id="btnScope">Toggle scope</button>
+    <button class="btn ghost" id="btnWalk">LED walk (w)</button>
+    <button class="btn ghost" id="btnLeds">Hide / show LEDs (t)</button>
+    <button class="btn ghost" id="btnScope">Toggle scope plot (s)</button>
+    <button class="btn ghost" id="btnPlotMute">Mute [PLOT] stream (m)</button>
     <button class="btn ghost" id="btnRefreshLog">Refresh log</button>
     <button class="btn ghost" id="btnReboot">Reboot</button>
     <button class="btn danger" id="btnForget">Forget WiFi</button>
+  </div>
+  <h2>Serial-only commands</h2>
+  <p style="color:var(--mut);font-size:.9em">These are useful when tethered to
+  a laptop over USB — they aren't worth a button:</p>
+  <div class="kv" style="font-size:.9em">
+    <b><code>help</code></b><span>print the full command list</span>
+    <b><code>vN</code></b><span>set runtime level 0..255 (use Status tile instead from UI)</span>
+    <b><code>r</code></b><span>dump reed raw + debounced state (Status pill shows this live)</span>
+    <b><code>k</code></b><span>recalibrate baseline (Phase B placeholder)</span>
   </div>
   <h2>Recent log</h2>
   <pre class="log" id="log">(loading)</pre>
@@ -283,13 +378,15 @@ function startSse(){
     applyStatus(d);
   };
 }
+// Track if the user is actively dragging a slider so SSE doesn't fight them.
+let dragging = null;     // "mist" | "wave" | null
+let lastNonZeroLevel = 255;
+function pctFromLevel(l){ return Math.round(l*100/255); }
+function levelFromPct(p){ return Math.max(0,Math.min(255,Math.round(p*255/100))); }
+
 function applyStatus(d){
-  // Status tab cards
+  // Live row + state cards
   $("vState").textContent=d.state;
-  $("vMist").textContent = d.mist
-      ? (d.ledsHidden?"ON (LEDs hidden)":"ON")
-      : "off";
-  $("cMist").classList.toggle("green",!!d.mist);
   $("vCurMa").textContent=d.meanMa.toFixed(1);
   $("cCur").classList.toggle("green",d.meanMa>50&&d.meanMa<500);
   $("cCur").classList.toggle("err",d.meanMa>=500);
@@ -301,13 +398,45 @@ function applyStatus(d){
   $("vHeap").textContent=d.freeHeap;
   $("vRssi").textContent=d.rssi+" dBm";
   $("setupBanner").hidden=!d.setupMode;
+  if(d.outdoorTempC!=null && d.outdoorHumidity!=null){
+    $("cWx").hidden=false;
+    $("vWxT").textContent=d.outdoorTempC.toFixed(1);
+    $("vWxH").textContent=d.outdoorHumidity.toFixed(0);
+  }
+
+  // Mist tile (toggle = level>0; slider = level%)
+  const mistOn = d.userLevel>0;
+  $("swMist").classList.toggle("on",mistOn);
+  const mistPct = pctFromLevel(d.userLevel);
+  $("mistPct").textContent = mistPct;
+  if(dragging!=="mist") $("mistSlider").value = mistPct;
+  $("mistSub").textContent = d.mist ? "flowing (docked)" :
+      (d.reedPresent ? "queued — waiting on settle" : "ready (no container)");
+  if(d.userLevel>0) lastNonZeroLevel = d.userLevel;
+
+  // LED Wave tile (toggle = ledsHidden inverse; slider mirrors level)
+  $("swWave").classList.toggle("on",!d.ledsHidden);
+  $("wavePct").textContent = mistPct;
+  if(dragging!=="wave") $("waveSlider").value = mistPct;
+  $("waveSub").textContent = d.ledsHidden ? "hidden (mist continues)" :
+      (d.state==="RUNNING" ? "swelling" : "breathing");
+
+  // Reed pill + status-LED pill
+  $("pReed").textContent = d.reedPresent ? "docked" : "empty";
+  const sOv = d.statLedOverride;
+  $("pStat").textContent = sOv===1 ? "forced ON" : sOv===0 ? "forced OFF" : "auto";
+  $("bStLAuto").classList.toggle("active",sOv===-1);
+  $("bStLOn").classList.toggle("active",sOv===1);
+  $("bStLOff").classList.toggle("active",sOv===0);
+
   // Debug tab raw row
   $("dCur").textContent=d.meanMa.toFixed(1);
   $("dVar").textContent=d.varMa2.toFixed(1);
   $("dReed").textContent=d.reedRaw;
   $("dBtn").textContent=d.btnRaw;
   $("dState").textContent=d.state+" ("+d.stateInt+")";
-  // Sparkline buffer (last 120 samples ≈ 30 s @ 4 Hz)
+
+  // Sparkline (last 120 samples ~30 s @ 4 Hz)
   sparkBuf.push(d.meanMa);
   if(sparkBuf.length>120) sparkBuf.shift();
   const max=Math.max(50,...sparkBuf);
@@ -318,6 +447,75 @@ function applyStatus(d){
   }).join(" ");
   $("sparkLine").setAttribute("points",pts);
 }
+
+// --- Status tile + override wiring -----------------------------------------
+async function postJson(path, body){
+  if(!ensureAdmin()) throw new Error("no auth");
+  const r = await fetch(path,{method:"POST",
+    headers:{"Content-Type":"application/json","Authorization":"Basic "+adminBasic()},
+    body: body ? JSON.stringify(body) : undefined});
+  if(r.status===401){ clearAdmin(); throw new Error("auth"); }
+  if(!r.ok) throw new Error("HTTP "+r.status);
+  return r.json().catch(()=>({}));
+}
+
+function bindLevelSlider(id, kind){
+  const el=$(id);
+  el.addEventListener("input",()=>{ dragging=kind; });
+  el.addEventListener("change",async()=>{
+    try{ await postJson("/api/cmd/level",{value:levelFromPct(+el.value)}); }
+    catch(e){ toast("Level: "+e.message,"err"); }
+    finally{ dragging=null; }
+  });
+}
+bindLevelSlider("mistSlider","mist");
+bindLevelSlider("waveSlider","wave");
+
+$("swMist").addEventListener("click",async()=>{
+  const wantOn = !$("swMist").classList.contains("on");
+  try{
+    await postJson("/api/cmd/level",{value: wantOn ? lastNonZeroLevel : 0});
+  } catch(e){ toast("Mist: "+e.message,"err"); }
+});
+$("swWave").addEventListener("click",async()=>{
+  try{ await postJson("/api/cmd/leds"); }
+  catch(e){ toast("LEDs: "+e.message,"err"); }
+});
+$("bForceRun").addEventListener("click",()=>postJson("/api/cmd/state",{state:"running"})
+  .then(()=>toast("Forced RUNNING","ok")).catch(e=>toast(e.message,"err")));
+$("bForceIdle").addEventListener("click",()=>postJson("/api/cmd/state",{state:"idle"})
+  .then(()=>toast("Forced IDLE","ok")).catch(e=>toast(e.message,"err")));
+$("bStLAuto").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"auto"}).catch(e=>toast(e.message,"err")));
+$("bStLOn").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"on"}).catch(e=>toast(e.message,"err")));
+$("bStLOff").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"off"}).catch(e=>toast(e.message,"err")));
+
+// --- Mist pulse depth (UI-friendly wrapper around cfg.mistWaveTroughQ8) ----
+// pulseDepth% 0..100 maps to troughQ8 = round((1-pulse/100)*256). 0% pulse
+// means trough=256 (constant), 100% pulse means trough=0 (full swing).
+function pulseFromTrough(troughQ8){ return Math.round(100*(256-troughQ8)/256); }
+function troughFromPulse(pct){ return Math.max(0,Math.min(256,Math.round((1-pct/100)*256))); }
+function syncPulseFromCfg(){
+  if(lastCfg && lastCfg.mistWaveTroughQ8!=null){
+    const p=pulseFromTrough(lastCfg.mistWaveTroughQ8);
+    $("pulseSlider").value=p; $("pulseNum").value=p;
+  }
+}
+$("pulseSlider").addEventListener("input",e=>{ $("pulseNum").value=e.target.value; });
+$("pulseNum").addEventListener("input",e=>{
+  let v=parseInt(e.target.value,10); if(isNaN(v)) return;
+  v=Math.max(0,Math.min(100,v));
+  $("pulseSlider").value=v;
+});
+$("bPulseSave").addEventListener("click",async()=>{
+  if(!ensureAdmin()) return;
+  const pct=parseInt($("pulseNum").value,10)||0;
+  const q8=troughFromPulse(pct);
+  try{
+    await postJson("/api/config",{field:"mistWaveTroughQ8",value:q8});
+    lastCfg.mistWaveTroughQ8=q8;
+    toast("Pulse depth saved","ok");
+  }catch(e){ toast("Save failed: "+e.message,"err"); }
+});
 
 // --- Config tab -------------------------------------------------------------
 function renderConfigForm(values){
@@ -351,6 +549,7 @@ async function loadConfig(){
     const r=await fetch("/api/config",{cache:"no-store"});
     lastCfg=await r.json();
     renderConfigForm(lastCfg);
+    syncPulseFromCfg();
   }catch(e){ toast("Failed to load config: "+e,"err"); }
 }
 async function saveOne(name,value){
@@ -413,6 +612,7 @@ async function postCmd(path,confirmMsg){
 $("btnWalk").addEventListener("click",()=>postCmd("/api/cmd/walk"));
 $("btnLeds").addEventListener("click",()=>postCmd("/api/cmd/leds"));
 $("btnScope").addEventListener("click",()=>postCmd("/api/cmd/scope"));
+$("btnPlotMute").addEventListener("click",()=>postCmd("/api/cmd/plotmute"));
 $("btnReboot").addEventListener("click",()=>postCmd("/api/cmd/reboot","Reboot the device?"));
 $("btnForget").addEventListener("click",()=>postCmd("/api/cmd/forget","Forget WiFi credentials and reboot into setup mode?"));
 
@@ -471,6 +671,11 @@ function clearAdmin(){ sessionStorage.removeItem("adminPwd"); }
 
 // --- Boot -------------------------------------------------------------------
 loadInfo();
+// Pull cfg once so the Status-tab pulse slider has a starting value, without
+// rendering the full config form (that happens lazily when Config tab opens).
+fetch("/api/config",{cache:"no-store"}).then(r=>r.json()).then(c=>{
+  lastCfg=c; syncPulseFromCfg();
+}).catch(()=>{});
 startSse();
 </script>
 </body>

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -121,7 +121,7 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
 <section id="status">
   <div id="setupBanner" class="setup-banner" hidden>
     Device is in WiFi setup mode. Join the
-    <code>BlockKit-Setup-XXXX</code> AP (password <code>blockkit-setup</code>).
+    <code>MistMaker-Setup-XXXX</code> AP (password <code>mistmaker-setup</code>).
   </div>
   <div class="cards">
     <div class="card" id="cState"><div class="lbl">State</div><div class="v" id="vState">-</div></div>
@@ -180,7 +180,7 @@ pre.log{background:#0a0b0e;border:1px solid var(--line);border-radius:var(--r);
   <h2>Device</h2>
   <div class="kv" id="aboutKv"><b>Hostname</b><span id="aHost">-</span></div>
   <h2>OTA</h2>
-  <p>Arduino IDE → <code>Tools → Port → blockkit at &lt;ip&gt; (esp32)</code>.
+  <p>Arduino IDE → <code>Tools → Port → mistmaker at &lt;ip&gt; (esp32)</code>.
   Password is the admin password set during WiFi setup. The device hard-stops
   the mist + boost rail before flash is erased.</p>
   <h2>Admin password</h2>

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -201,13 +201,12 @@ details.adv>div{padding:0 14px 14px}
     </div>
   </details>
 
-  <!-- Compact live row + sparkline + weather (weather hidden until configured) -->
+  <!-- Compact live row + sparkline -->
   <h2>Live</h2>
   <div class="cards">
     <div class="card" id="cState"><div class="lbl">State</div><div class="v" id="vState">-</div></div>
     <div class="card" id="cCur"><div class="lbl">Current</div><div class="v"><span id="vCurMa">-</span> mA</div></div>
     <div class="card" id="cUp"><div class="lbl">Uptime</div><div class="v" id="vUp">-</div></div>
-    <div class="card" id="cWx" hidden><div class="lbl">Outdoor</div><div class="v"><span id="vWxT">-</span>&deg;C / <span id="vWxH">-</span>%</div></div>
   </div>
   <div class="row" style="margin-top:8px">
     <span>Button raw <b id="vBtn">-</b></span>
@@ -398,11 +397,6 @@ function applyStatus(d){
   $("vHeap").textContent=d.freeHeap;
   $("vRssi").textContent=d.rssi+" dBm";
   $("setupBanner").hidden=!d.setupMode;
-  if(d.outdoorTempC!=null && d.outdoorHumidity!=null){
-    $("cWx").hidden=false;
-    $("vWxT").textContent=d.outdoorTempC.toFixed(1);
-    $("vWxH").textContent=d.outdoorHumidity.toFixed(0);
-  }
 
   // Mist tile (toggle = level>0; slider = level%)
   const mistOn = d.userLevel>0;

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -455,11 +455,15 @@ async function postJson(path, body){
 
 function bindLevelSlider(id, kind){
   const el=$(id);
-  el.addEventListener("input",()=>{ dragging=kind; });
+  // Mark dragging on pointerdown (covers mouse + touch); clear on pointerup
+  // BEFORE the async POST runs, so a slow fetch doesn't widen the suppression
+  // window. Keyboard arrow-key changes still fire "change" without ever
+  // setting dragging — they just send the value, which is fine.
+  el.addEventListener("pointerdown",()=>{ dragging=kind; });
+  el.addEventListener("pointerup",  ()=>{ dragging=null; });
   el.addEventListener("change",async()=>{
     try{ await postJson("/api/cmd/level",{value:levelFromPct(+el.value)}); }
     catch(e){ toast("Level: "+e.message,"err"); }
-    finally{ dragging=null; }
   });
 }
 bindLevelSlider("mistSlider","mist");
@@ -475,8 +479,13 @@ $("swWave").addEventListener("click",async()=>{
   try{ await postJson("/api/cmd/leds"); }
   catch(e){ toast("LEDs: "+e.message,"err"); }
 });
-$("bForceRun").addEventListener("click",()=>postJson("/api/cmd/state",{state:"running"})
-  .then(()=>toast("Forced RUNNING","ok")).catch(e=>toast(e.message,"err")));
+$("bForceRun").addEventListener("click",()=>{
+  // Forcing RUNNING re-arms the mist regardless of reed state. Confirm so a
+  // stray tap doesn't engage the piezo on an empty bottle.
+  if(!confirm("Force RUNNING? This re-arms the mist regardless of whether a container is docked. Use only for testing without a magnet.")) return;
+  postJson("/api/cmd/state",{state:"running"})
+    .then(()=>toast("Forced RUNNING","ok")).catch(e=>toast(e.message,"err"));
+});
 $("bForceIdle").addEventListener("click",()=>postJson("/api/cmd/state",{state:"idle"})
   .then(()=>toast("Forced IDLE","ok")).catch(e=>toast(e.message,"err")));
 $("bStLAuto").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"auto"}).catch(e=>toast(e.message,"err")));

--- a/variants/block-kit/firmware/BlockKit_Production/wifi_setup.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/wifi_setup.ino
@@ -1,6 +1,6 @@
 // WiFi onboarding via tzapu's WiFiManager.
 // On boot: autoConnect() joins saved STA; on first boot or gone-AP it spins
-// up "BlockKit-Setup-XXXX" (WPA2, pwd `blockkit-setup`) as a captive portal.
+// up "MistMaker-Setup-XXXX" (WPA2, pwd `mistmaker-setup`) as a captive portal.
 // WiFiManager handles iOS/Android/Windows captive-portal probes for us.
 
 #include <WiFi.h>
@@ -28,7 +28,7 @@ static const char* apSsid() {
   if (ssid[0]) return ssid;
   uint8_t mac[6];
   WiFi.macAddress(mac);
-  snprintf(ssid, sizeof(ssid), "BlockKit-Setup-%02X%02X", mac[4], mac[5]);
+  snprintf(ssid, sizeof(ssid), "MistMaker-Setup-%02X%02X", mac[4], mac[5]);
   return ssid;
 }
 
@@ -40,7 +40,7 @@ static void onConfigPortalStart(WiFiManager* /*wm*/) {
   g_setupMode = true;
   Serial.println("[WIFI] captive portal up");
   Serial.print  ("[WIFI] SSID: ");      Serial.println(apSsid());
-  Serial.println("[WIFI] password: blockkit-setup");
+  Serial.println("[WIFI] password: mistmaker-setup");
   Serial.println("[WIFI] join the AP then browse to 192.168.4.1 or any URL");
 }
 
@@ -85,11 +85,11 @@ void wifiInit() {
   g_wm.setShowInfoUpdate(false);
   g_wm.setAPCallback(onConfigPortalStart);
   g_wm.setSaveConfigCallback(onCredentialsSaved);
-  g_wm.setTitle("Block Kit Setup");
+  g_wm.setTitle("Mist Maker Setup");
   g_wm.setDarkMode(true);
 
   Serial.println("[WIFI] autoConnect...");
-  const bool ok = g_wm.autoConnect(apSsid(), "blockkit-setup");
+  const bool ok = g_wm.autoConnect(apSsid(), "mistmaker-setup");
   if (!ok) {
     Serial.println("[WIFI] autoConnect timeout — rebooting");
     delay(500);

--- a/variants/block-kit/firmware/MATTER_VARIANT_PLAN.md
+++ b/variants/block-kit/firmware/MATTER_VARIANT_PLAN.md
@@ -1,0 +1,128 @@
+# Matter Variant — Plan (no code yet)
+
+## Why a separate variant
+
+The current `BlockKit_Production` sketch is at **95% of the default 1.3 MB app
+partition**. Adding the Matter SDK pushes a typical minimal Matter example to
+~1.6 MB on its own (per Espressif's ESP-Matter docs); stacked on top of our
+existing WiFi/OTA/web UI it would not fit even on a 1.9 MB OTA partition.
+
+A separate sketch (`BlockKit_Matter`) lets us:
+- Pick a custom partition table sized for Matter (2 MB+ app, smaller SPIFFS).
+- Drop features we don't need on the Matter path (the synchronous web UI is
+  redundant once Apple Home / Google Home / Aqara own the control surface).
+- Use ESP-IDF tooling where Arduino-on-top-of-IDF struggles (Matter's commissioning + Thread bring-up are easier in pure IDF).
+
+The hardware is the same (XIAO ESP32-C6). Users pick which firmware to flash
+based on what they want — fully local web UI (current production firmware)
+**or** Matter-native pairing into a smart-home app (new variant).
+
+## Target capabilities
+
+The Matter spec calls our device a **Humidifier** (cluster `0x0072`). At v1.0
+of the variant we'll implement the minimum surface:
+
+- On/Off (cluster `0x0006`) — turn mist on/off.
+- Level Control (cluster `0x0008`) — set mist intensity 0–100%.
+- Humidifier (cluster `0x0072`) — current humidity mode.
+- Identify (cluster `0x0003`) — blink LEDs when the smart-home app pings
+  "identify this device" during commissioning.
+
+Stretch (post-v1):
+- Humidifier Concentration measurement (`0x0405`) reporting the desired
+  humidity setpoint.
+- Outdoor environmental data via thread border router → matter weather.
+
+## QR code / commissioning
+
+Matter uses a deterministic setup payload:
+`MT:<Base38 of {VID,PID,discriminator,passcode,...}>`. Espressif's
+`esp_matter` SDK generates this string at boot and provides:
+1. A printable QR string (we'll print to Serial + show in initial setup AP).
+2. A 32-char numeric setup code (the fallback when scanning fails).
+
+The user scans the QR with the Apple Home / Google Home / Aqara app. The
+device performs DNS-SD advertisement (`_matterc._udp` on WiFi, optionally
+`_matter._tcp` on Thread once commissioned). After pairing the app owns
+control — no more captive portal needed.
+
+QR code RENDERING in the web UI is optional: ESP-Matter prints the payload;
+we can render an SVG QR on a dedicated `/qr` route at first boot.
+
+## Partition layout
+
+For a 4 MB flash XIAO ESP32-C6, target layout:
+
+```
+# Name,        Type, SubType, Offset,   Size
+nvs,           data, nvs,     0x9000,   0x6000
+otadata,       data, ota,     0xf000,   0x2000
+nvs_keys,      data, nvs_keys,0x11000,  0x1000   # for Matter DAC keystore
+phy_init,      data, phy,     0x12000,  0x1000
+app0,          app,  ota_0,   0x20000,  0x1F0000 # ~2 MB primary
+app1,          app,  ota_1,   0x210000, 0x1E0000 # ~1.9 MB secondary
+factory_mfg,   data, nvs,     0x3F0000, 0x6000   # Matter factory data
+fctry,         data, nvs,     0x3F6000, 0x6000   # ESP-Matter factory namespace
+matter_kvs,    data, nvs,     0x3FC000, 0x4000   # Matter runtime KVS
+```
+
+Total: 4 MB. Mature Matter + WiFi + OTA all fit; identical for ESP32-S3
+hardware.
+
+## Build approach
+
+**Two options, decision deferred until prototyping:**
+
+1. **arduino-esp32 v3.x + esp_matter library** — easier, all in Arduino IDE,
+   but the Arduino Matter library lags ESP-IDF and may not expose every
+   cluster we need.
+2. **ESP-IDF + esp_matter** — full Espressif stack, requires `idf.py` build
+   instead of Arduino. More setup pain, more capability.
+
+We'd start with (1), fall back to (2) if blocked. Either path produces a
+`.bin` flashable to the same XIAO board the current firmware runs on.
+
+## What stays / what goes vs the current firmware
+
+| Module | Matter variant |
+|---|---|
+| `pins.h` | reuse as-is |
+| `mist.ino` | reuse — Matter cluster handlers call `mistApply()` |
+| `led_driver.ino` | reuse — Matter Identify calls `ledWalk()` for blink |
+| `container.ino` | reuse — drives state machine |
+| `button.ino` | reuse — long-press = factory reset (Matter spec) |
+| `current_sense.ino` | reuse for diagnostics |
+| `BlockKit_Matter.ino` | NEW — state machine + Matter callbacks (replaces `BlockKit_Production.ino`) |
+| `web_server.ino`, `web_ui.h` | **drop** — Matter app owns control |
+| `wifi_setup.ino` | replace with Matter's commissioning flow |
+| `ota.ino` | replace with Matter OTA Update Cluster |
+| `config.ino`, `config.h` | trimmed — keep hardware-level NVS, lose web-UI fields |
+
+## First milestone (proof of concept)
+
+1. Clone the production firmware tree into `variants/block-kit/firmware/BlockKit_Matter/`.
+2. Strip web UI + OTA + WiFiManager.
+3. Drop in the partition table above.
+4. Add `esp_matter` library, copy the Humidifier example.
+5. Wire On/Off and Level Control cluster handlers to `mistEnable()` and
+   `appSetLevel()`.
+6. Print the QR setup payload on serial.
+7. Commission with Apple Home — get to "mist on/off works from iPhone".
+
+## What we'd want from the user before starting
+
+- Choice of smart-home app to target first (Apple, Google, Aqara, Home
+  Assistant, all of them).
+- Whether OTA over Matter is required for v1, or USB flash is OK during
+  prototyping.
+- Decision on whether the standalone web UI (the current production firmware)
+  should remain available as an alternate flash, or be deprecated entirely.
+
+## Estimated effort
+
+- Prototyping (Arduino + Matter library): 2–3 days.
+- Polish + commissioning UX + factory-reset button: 1–2 days.
+- Full Matter compliance + multi-app testing: 1 week.
+
+A separate plan/PR opens that work; nothing in this firmware needs to change
+to start that track.


### PR DESCRIPTION
## Summary

Three things, stacked on top of the simplification PR (#9):

1. **Network identity rebrand: `mistmaker.local`**. Hostname default, AP SSID prefix (`MistMaker-Setup-XXXX`), and AP password (`mistmaker-setup`) all updated. NVS namespace stays `"blockkit"` so existing user configs survive the upgrade.

2. **UI/UX redesign**:
   - Status tab top: two big tiles — Mist (toggle + percent slider + flowing/ready sub) and LED Wave (toggle = hide/show, slider mirrors mist level). Below the tiles: reed pill with Force IDLE / Force RUNNING override buttons; indicator-LED pill with Auto / On / Off override buttons.
   - **Friendly Mist Pulse Depth slider** (0-100%) right under the tiles. Translates to/from `cfg.mistWaveTroughQ8` so you can dial in how visible the breathing is without thinking in Q8 (0% = constant mist, 100% = full wave-synced swing).
   - Config tab: everything moved into a collapsed `<details>` panel labeled "Advanced settings". The form is no longer the first thing you see.
   - Debug tab: added Mute [PLOT] stream button + a Serial-only commands cheat sheet so it's clear what serial does that the UI does NOT cover (`help`, `vN`, `r`, `k`).

3. **Matter variant planning doc** at `variants/block-kit/firmware/MATTER_VARIANT_PLAN.md`. No code yet — the spec for a future `BlockKit_Matter` sketch that would pair via Apple Home / Google Home / Aqara with a QR setup payload. Separate variant because Matter SDK won't fit alongside the existing web UI + OTA.

### New endpoints (all admin-auth gated)
| Endpoint | Body | Action |
|---|---|---|
| `POST /api/cmd/level` | `{value:0..255}` | Set runtime userLevel (mirrors serial `vN`) |
| `POST /api/cmd/state` | `{state:"idle"|"running"}` | Force state machine transition (testing without a magnet) |
| `POST /api/cmd/statled` | `{mode:"auto"|"on"|"off"}` | Override indicator LED |
| `POST /api/cmd/plotmute` | (no body) | Toggle [PLOT] CSV stream |

Force RUNNING shows a confirm dialog — it re-arms mist regardless of reed state, so a stray tap shouldn't engage the piezo on an empty bottle.

### What's NOT in this PR
- **Open-Meteo weather**: explored, hit the flash ceiling (would have needed a custom 1.9MB partition table). Rolled back per your "if too much, do not add it" call. Could revisit by bumping partitions later.
- **Matter implementation**: planning doc only — that's a separate flash budget conversation and probably a parallel sketch.

### Verification
- `arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32C6 --libraries ~/Documents/Arduino/libraries variants/block-kit/firmware/BlockKit_Production` passes clean. **1257322 bytes (95% of 1.3MB flash)**.
- Codex review: 2 actionable findings, both fixed in commit 93a9694 (slider race + force-RUNNING confirm).
- Built-in review: clean.

## Test plan

- [x] arduino-cli compile passes (95% flash, no new warnings)
- [x] Codex review feedback addressed
- [x] Self-review final pass
- [ ] **Hardware smoke test** (run before merge):
  - [ ] First boot: confirm new AP `MistMaker-Setup-XXXX` appears; mDNS resolves at `mistmaker.local`
  - [ ] Status tab: both tiles render, sliders move, toggles flip mist/wave correctly
  - [ ] Drag mist slider quickly — should not snap back from SSE (race fix)
  - [ ] Tap Force RUNNING with no container — confirm dialog appears; on confirm, mist engages
  - [ ] Set indicator LED to On / Off / Auto — confirm D7 follows
  - [ ] Move pulse-depth slider, save, verify mist swing changes
  - [ ] Verify existing NVS config (admin password, hostname) survives the upgrade
  - [ ] OTA upload still works at `mistmaker.local`

Generated with [Claude Code](https://claude.com/claude-code)
