### PR TITLE
Factory reset (triple-tap + button) + safety caps + boot-mist fix

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -16,6 +16,8 @@
 // hard-stops mist (see ota.ino); boost rail is forced LOW first in setup().
 
 #include <Wire.h>
+#include <Preferences.h>
+#include <nvs_flash.h>
 #include "pins.h"
 #include "config.h"
 
@@ -76,6 +78,59 @@ static uint32_t g_lastLedScaleMs   = 0;
 static void enterIdle();
 static void enterRunning();
 static void enterTransitionFromRunning();
+
+// ----------------------------------------------------------------------
+// Factory reset via triple-tap of the physical reset button.
+//
+// On every boot we increment a counter in a dedicated NVS namespace. After
+// the device runs cleanly for TAP_CLEAR_MS we wipe the counter. If the
+// user resets TAP_THRESHOLD times in a row (each boot reaching less than
+// TAP_CLEAR_MS), nvs_flash_erase() wipes the entire NVS partition —
+// blockkit config blob, admin/OTA passwords, WiFi credentials, RF cal —
+// and the device reboots into the captive portal as if it were factory new.
+// ----------------------------------------------------------------------
+static constexpr const char* TAP_NS         = "factory";
+static constexpr const char* TAP_KEY        = "rc";
+static constexpr uint8_t     TAP_THRESHOLD  = 3;
+static constexpr uint32_t    TAP_CLEAR_MS   = 5000;
+static uint32_t g_tapClearAtMs = 0;
+
+static void appNvsWipeAndReboot() {
+  Serial.println("[FACTORY] wiping NVS partition + rebooting");
+  Serial.flush();
+  // Safety: cut the boost rail before the (blocking) NVS erase.
+  pinMode(PIN_BOOST_EN, OUTPUT);
+  digitalWrite(PIN_BOOST_EN, LOW);
+  nvs_flash_erase();   // wipes blockkit cfg, WiFi creds, WiFiManager state, RF cal
+  nvs_flash_init();    // re-init the empty partition so next boot is clean
+  delay(100);
+  ESP.restart();
+}
+
+static void checkAndArmTapCounter() {
+  Preferences p;
+  if (!p.begin(TAP_NS, /*readOnly=*/false)) return;
+  const uint8_t count = uint8_t(p.getUChar(TAP_KEY, 0) + 1);
+  p.putUChar(TAP_KEY, count);
+  p.end();
+  Serial.printf("[FACTORY] reset-tap counter: %u/%u\n", count, TAP_THRESHOLD);
+  if (count >= TAP_THRESHOLD) appNvsWipeAndReboot();  // never returns
+  g_tapClearAtMs = millis() + TAP_CLEAR_MS;
+}
+
+static void clearTapCounterIfStable() {
+  if (g_tapClearAtMs == 0) return;
+  if (millis() < g_tapClearAtMs) return;
+  Preferences p;
+  if (p.begin(TAP_NS, /*readOnly=*/false)) {
+    p.putUChar(TAP_KEY, 0);
+    p.end();
+  }
+  g_tapClearAtMs = 0;
+}
+
+// Public entry — called by /api/cmd/factory-reset.
+void appFactoryReset() { appNvsWipeAndReboot(); }
 
 // ----------------------------------------------------------------------
 // State transitions
@@ -468,6 +523,11 @@ void setup() {
   pinMode(PIN_BOOST_EN, OUTPUT);
   digitalWrite(PIN_BOOST_EN, LOW);
 
+  // Reset-tap detection runs BEFORE configInit() so a bad saved config
+  // (e.g. mistDutyMax pushed past 200 → boost hiccup → WiFi unreachable)
+  // can be wiped by triple-tapping the reset button.
+  checkAndArmTapCounter();
+
   // Mirror Serial into a RAM ring buffer so the web UI's Debug tab can show
   // the recent log without USB attached.
   logInit();
@@ -525,6 +585,7 @@ void loop() {
   currentSenseTick();
   smoothLevel();
   smoothLedScale();
+  clearTapCounterIfStable();   // 5 s after boot, reset the triple-tap counter
 
   // Apply smoothed level to outputs.
   //

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -277,9 +277,13 @@ bool configSetField(const char* name, long value) {
   SET_U16(wavePeriodMs,          "wavePeriodMs",        500, 60000);
   SET_U16(ledCrossfadeMs,        "ledCrossfadeMs",      0, 10000);
   SET_U8 (ledScaleStepPerTick,   "ledScaleStepPerTick", 1, 255);
-  // Mist
-  SET_U8 (mistDutyMax,           "mistDutyMax",         0, 255);
-  SET_U8 (mistDutyMin,           "mistDutyMin",         0, 255);
+  // Mist. Hardware-safe cap is 200 (~78% duty). Above that the piezo's peak
+  // current at 108.7 kHz exceeds the TPS61023 boost converter's ~2 A current
+  // limit, the boost goes into hiccup mode, the battery rail develops large
+  // ripple, and WiFi browns out — the device becomes unreachable on the LAN.
+  // Bench-validated: 200 holds stable, 220+ triggers the cascade.
+  SET_U8 (mistDutyMax,           "mistDutyMax",         0, 200);
+  SET_U8 (mistDutyMin,           "mistDutyMin",         0, 200);
   SET_U8 (levelDefault,          "levelDefault",        0, 255);
   SET_U16(mistWaveTroughQ8,      "mistWaveTroughQ8",    0, 256);
   // Smoother

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -277,13 +277,14 @@ bool configSetField(const char* name, long value) {
   SET_U16(wavePeriodMs,          "wavePeriodMs",        500, 60000);
   SET_U16(ledCrossfadeMs,        "ledCrossfadeMs",      0, 10000);
   SET_U8 (ledScaleStepPerTick,   "ledScaleStepPerTick", 1, 255);
-  // Mist. Hardware-safe cap is 200 (~78% duty). Above that the piezo's peak
-  // current at 108.7 kHz exceeds the TPS61023 boost converter's ~2 A current
-  // limit, the boost goes into hiccup mode, the battery rail develops large
-  // ripple, and WiFi browns out — the device becomes unreachable on the LAN.
-  // Bench-validated: 200 holds stable, 220+ triggers the cascade.
-  SET_U8 (mistDutyMax,           "mistDutyMax",         0, 200);
-  SET_U8 (mistDutyMin,           "mistDutyMin",         0, 200);
+  // Mist. Hardware-safe cap is 170 (~67% duty). Bench shows 200 (~78%) is
+  // the empirical edge where the TPS61023 boost converter's ~2 A current
+  // limit is reached and the rail starts hiccupping, browning out WiFi.
+  // Capping at 170 leaves headroom for piezo-to-piezo variation, battery
+  // sag at low SoC, and temperature drift — values above 170 should not
+  // be needed for normal operation since the default is 127 (50% duty).
+  SET_U8 (mistDutyMax,           "mistDutyMax",         0, 170);
+  SET_U8 (mistDutyMin,           "mistDutyMin",         0, 170);
   SET_U8 (levelDefault,          "levelDefault",        0, 255);
   SET_U16(mistWaveTroughQ8,      "mistWaveTroughQ8",    0, 256);
   // Smoother

--- a/variants/block-kit/firmware/BlockKit_Production/mist.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/mist.ino
@@ -14,7 +14,15 @@ static bool g_mistBoostOn   = false;
 // is a no-op. This is the lock that prevents the LED-fade smoother (which
 // still feeds non-zero `level` during the fade) from re-engaging the boost
 // rail seconds after the container has been lifted.
-static bool g_mistInhibited = false;
+//
+// Boot-safe default = true. At power-on the state machine sits in IDLE but
+// the level smoother ramps g_currentLevel from 0 toward g_targetLevel
+// (= cfg.levelDefault, usually 255). Without this default-inhibit, the
+// boost rail would engage and the piezo would run for ~1.3 s before the
+// reed debounce fires Inserted — i.e. mist before the container is checked.
+// enterRunning() calls mistEnable(true) to unlock once a real Inserted
+// event arrives from containerPoll().
+static bool g_mistInhibited = true;
 
 void mistInit() {
   pinMode(PIN_BOOST_EN, OUTPUT);

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -14,6 +14,7 @@
 //   POST /api/cmd/statled   override indicator LED; body = {"mode":"auto|on|off"}
 //   POST /api/cmd/reboot    ESP.restart() after 250 ms
 //   POST /api/cmd/forget    wipe WiFi creds + reboot into captive portal
+//   POST /api/cmd/factory-reset  wipe ALL NVS (config + WiFi + admin pwd) + reboot
 //   POST /api/cmd/password  set new admin password; body = {"new":"..."}
 //   GET  /api/events        Server-Sent Events stream (status every 250 ms)
 //   GET  /api/log           recent log lines (plain text)
@@ -37,6 +38,7 @@ extern void     appSetLevel(uint8_t);
 extern void     appForceState(AppState);
 extern void     appSetStatusLedOverride(int8_t);
 extern int8_t   appStatusLedOverride();
+extern void     appFactoryReset();
 extern bool     containerIsPresent();
 extern bool     containerRawPresent();
 extern bool     mistIsRunning();
@@ -367,6 +369,17 @@ static void handleCmdForget() {
   wifiForgetAndReboot();
 }
 
+// Wipes the entire NVS partition (config blob, admin/OTA passwords, WiFi
+// credentials, RF cal) and reboots. The device comes back as factory-new
+// and lands in the captive portal. Equivalent to the physical triple-tap
+// reset; this is the same recovery path exposed to the web UI.
+static void handleCmdFactoryReset() {
+  if (!requireAuth()) return;
+  g_http.send(200, "application/json", "{\"ok\":true,\"factoryReset\":250}");
+  delay(250);
+  appFactoryReset();   // never returns
+}
+
 static void handleCmdPassword() {
   if (!requireAuth()) return;
   const String body = g_http.arg("plain");
@@ -456,6 +469,7 @@ void webInit() {
   g_http.on("/api/cmd/statled",     HTTP_POST, handleCmdStatLed);
   g_http.on("/api/cmd/reboot",      HTTP_POST, handleCmdReboot);
   g_http.on("/api/cmd/forget",      HTTP_POST, handleCmdForget);
+  g_http.on("/api/cmd/factory-reset", HTTP_POST, handleCmdFactoryReset);
   g_http.on("/api/cmd/password",    HTTP_POST, handleCmdPassword);
   g_http.onNotFound([]() {
     g_http.send(404, "application/json", "{\"error\":\"not found\"}");

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -373,7 +373,19 @@ static void handleCmdForget() {
 // credentials, RF cal) and reboots. The device comes back as factory-new
 // and lands in the captive portal. Equivalent to the physical triple-tap
 // reset; this is the same recovery path exposed to the web UI.
+//
+// Security note: unlike the other endpoints, we DO NOT honor the first-boot
+// open-access grace period for this one. If no admin password is set yet,
+// the only network path is rejected — recovery must happen via the physical
+// triple-tap reset (which requires hands on the device). This prevents a
+// LAN attacker from DoS-wiping a freshly-provisioned device.
 static void handleCmdFactoryReset() {
+  if (cfg.adminPasswordHash[0] == '\0') {
+    g_http.send(403, "application/json",
+                "{\"error\":\"factory-reset requires admin password (set one in About, "
+                "or use triple-tap of the physical reset button)\"}");
+    return;
+  }
   if (!requireAuth()) return;
   g_http.send(200, "application/json", "{\"ok\":true,\"factoryReset\":250}");
   delay(250);

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -277,6 +277,12 @@ details.adv>div{padding:0 14px 14px}
   <p>Arduino IDE → <code>Tools → Port → mistmaker at &lt;ip&gt; (esp32)</code>.
   Password is the admin password set during WiFi setup. The device hard-stops
   the mist + boost rail before flash is erased.</p>
+  <h2>Recovery</h2>
+  <p style="color:var(--mut)">If the device is unreachable on the network (bad
+  config, lost password, etc.), <b>press the physical reset button 3 times in
+  a row</b> — within ~5 seconds of each boot. The firmware wipes all NVS and
+  reboots into the captive portal so you can start fresh. Same effect as
+  clicking "Reset to defaults" in Config (which requires the admin password).</p>
   <h2>Admin password</h2>
   <p style="color:var(--mut)">Set or change the password used for config writes,
   commands, and OTA.</p>
@@ -580,16 +586,12 @@ $("btnSave").addEventListener("click",async()=>{
 });
 $("btnRevert").addEventListener("click",loadConfig);
 $("btnDefaults").addEventListener("click",async()=>{
-  if(!confirm("Reset every tunable to firmware defaults? (Saved to NVS.)")) return;
+  if(!confirm("Factory reset wipes EVERYTHING — all config, WiFi credentials, AND your admin password. The device reboots into setup mode and you'll redo the captive portal. Continue?")) return;
   if(!ensureAdmin()) return;
-  // Re-fire the SAME values as configResetDefaults yields by sending each
-  // CFG_DEFAULT_* — simpler client-side: ask server to roll back.
-  // For now: pull current defaults via a fresh GET after an empty body POST
-  // — but the API doesn't expose that. Easiest path: prompt the user to
-  // power-cycle after we forget the saved blob via /api/cmd/reboot.
-  // (Lightweight implementation: just set every visible field to its `lo`
-  // bound. Improvement tracked in TODO.)
-  alert("Defaults reset: please use Debug → Reboot, then on first boot the firmware defaults will load. (Full reset endpoint TBD.)");
+  try{
+    await postJson("/api/cmd/factory-reset");
+    toast("Factory reset triggered — device rebooting","ok");
+  }catch(e){ toast("Failed: "+e.message,"err"); }
 });
 
 // --- Debug tab --------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four interlocking fixes for safety and recoverability:

1. **Hardware-safe cap on mist duty values** — `mistDutyMax` and `mistDutyMin` capped at **170 (~67% duty)** in `configSetField()` validation. Bench shows 200 is the empirical edge where the TPS61023 boost converter's ~2 A current limit is reached and the rail starts hiccupping, which browns out WiFi. Capping at 170 leaves headroom for piezo-to-piezo variation, battery sag at low SoC, and temperature drift. The UI now physically cannot save a config that bricks the device.

2. **Boot-safe mist inhibit** — `g_mistInhibited` now defaults to `true` in `mist.ino`. Before this fix, at power-on the state machine sat in IDLE but the level smoother ramped `g_currentLevel` from 0 → cfg.levelDefault. The mist would briefly engage during that ramp, *before* the reed debounce confirmed a docked container. Now the boost rail stays locked until `enterRunning()` is reached via a real container event.

3. **Triple-tap-reset factory recovery** — Press the physical reset button 3 times in a row (each tap within ~5 s of the previous boot) and the firmware wipes the entire NVS partition: config blob, admin/OTA passwords, WiFi credentials, RF calibration. Device reboots into the captive portal as if it were factory-new. Self-healing: even if `setup()` crashes before reaching the counter clear, the counter just stays incremented and the next reset triggers a wipe. This is the recovery path when the web UI is unreachable.

4. **Working "Reset to defaults" button** — The web UI button at `Config → Reset to defaults` was previously a placeholder that just showed an alert. It now calls a new `POST /api/cmd/factory-reset` endpoint that does the same NVS wipe as the triple-tap path. Both paths share `appFactoryReset()` so behavior is identical. Confirm dialog is now honest about wiping admin password and WiFi creds.

### Security gate (Codex review fix)

The new `/api/cmd/factory-reset` endpoint **does not honor the first-boot open-access grace period** that the other admin endpoints use. If no admin password is set yet, the endpoint returns `403` with a helpful error pointing to the triple-tap recovery path. This closes the DoS hole where a LAN attacker could wipe a freshly-provisioned device before the user finishes setting an admin password. The triple-tap path remains open (and requires physical access).

## Verification

- `arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32C6 --libraries ~/Documents/Arduino/libraries variants/block-kit/firmware/BlockKit_Production` clean throughout. **1259114 bytes (96%)**. Free: ~52 KB.
- Codex review: 1 finding (open-access factory-reset risk), addressed in commit `ee729fe`.
- Self-review final pass: clean.

## Test plan

- [x] arduino-cli compile passes
- [x] Codex review feedback applied
- [x] Self-review pass
- [ ] **Hardware smoke test** (run before merge):
  - [ ] Power-cycle device with NO container docked. Confirm mist does NOT engage during the boot-time level ramp.
  - [ ] Power-cycle WITH container docked. Confirm mist engages only after the ~500 ms reed debounce completes.
  - [ ] Try to save `mistDutyMax = 200` via web UI Config form — should reject with "out of range" (cap is now 170).
  - [ ] Triple-tap reset button (3 quick presses). Confirm serial log shows `[FACTORY] reset-tap counter: 3/3`, `[FACTORY] wiping NVS partition + rebooting`, then captive portal AP appears.
  - [ ] In web UI, click "Reset to defaults" with admin password set. Confirm wipe + reboot.
  - [ ] In web UI on a fresh device with no admin password, attempt the reset endpoint — should fail with 403.

## Future watch

Flash is now at 96% (~52 KB free). The Matter variant plan (`variants/block-kit/firmware/MATTER_VARIANT_PLAN.md`) is the canonical path forward for big new features that don't fit. Smaller additions (a few hundred bytes) still fit cleanly.

Generated with [Claude Code](https://claude.com/claude-code)
