### PR TITLE
Phase B: piezo current-sense classifier (disc + water)

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -41,6 +41,7 @@ float      piezoLastProbeMa();
 uint32_t   piezoWaterCountdownS();
 void       piezoResetForNewDock();
 void       piezoSensePeriodicWaterCheck();
+void       piezoSensePeriodicDiscCheck();
 bool       piezoAutoProbeForDisc();
 float      piezoCalibrateWaterBaseline();
 // New in production firmware:
@@ -618,6 +619,7 @@ void loop() {
   // IDLE+useAsReed runs the auto-probe for dock detection. Mutually exclusive.
   if (g_state == AppState::RUNNING) {
     piezoSensePeriodicWaterCheck();
+    if (cfg.senseUseAsReed) piezoSensePeriodicDiscCheck();   // reed events are ignored — need fast removal signal
     const PiezoState ps = piezoState();
     if (ps == PiezoState::WATER_DEPLETED || ps == PiezoState::DISC_DISCONNECTED) {
       Serial.println(ps == PiezoState::WATER_DEPLETED

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -409,17 +409,12 @@ static void pollSerial() {
 // happen here, never inside the leaf modules.
 // ----------------------------------------------------------------------
 static void onContainerEvent(ContainerEvent ev) {
-  // When the user has configured current-sense as the dock detector, the reed
-  // switch's electrical state is irrelevant. piezoAutoProbeForDisc() in the
-  // main loop drives dock detection instead. Returning here keeps the reed
-  // hardware tolerated-but-ignored — no rip-out required.
+  // In useAsReed mode the reed hardware is tolerated-but-ignored; auto-probe
+  // drives dock detection instead.
   if (cfg.senseUseAsReed) return;
 
   if (ev == ContainerEvent::Inserted) {
-    // Fresh dock — clear any lingering classifier state from the last run
-    // (countdown, fault). Sets g_piezoState=UNKNOWN; the first water probe
-    // in RUNNING will reclassify.
-    piezoResetForNewDock();
+    piezoResetForNewDock();   // clear stale classifier state for the fresh dock
     // Docking always wins — from any state, including TRANSITION_FROM_RUNNING
     // mid-fade. enterRunning() is idempotent if we're already RUNNING.
     enterRunning();
@@ -427,11 +422,7 @@ static void onContainerEvent(ContainerEvent ev) {
     // Only RUNNING triggers the cinematic. From IDLE states, removal is a
     // no-op (container wasn't there in the model). From TRANSITION_FROM_
     // RUNNING, we're already on our way out — let the smoother finish.
-    if (g_state == AppState::RUNNING) {
-      enterTransitionFromRunning();
-    }
-    // Reed-removal also clears any lingering piezo fault so a fresh dock
-    // probes against a clean slate.
+    if (g_state == AppState::RUNNING) enterTransitionFromRunning();
     piezoResetForNewDock();
   }
 }
@@ -623,15 +614,8 @@ void loop() {
   onContainerEvent(containerPoll());
   onButtonEvent(buttonPoll());
 
-  // Piezo-sense classifier — two paths, mutually exclusive on senseUseAsReed.
-  //
-  // (1) RUNNING: periodic water-level probe. The function rate-limits itself
-  // to one probe per cfg.senseWaterCheckIntervalS, briefly forcing PWM to
-  // senseWaterProbeDuty for ~100 ms. If it classifies WATER_DEPLETED or
-  // DISC_DISCONNECTED, fade out via enterTransitionFromRunning().
-  //
-  // (2) IDLE + senseUseAsReed: auto-probe at PWM=10 every
-  // cfg.senseAutoProbeIntervalS to detect a fresh dock without the reed.
+  // Piezo classifier dispatch — RUNNING runs the water probe + fault check;
+  // IDLE+useAsReed runs the auto-probe for dock detection. Mutually exclusive.
   if (g_state == AppState::RUNNING) {
     piezoSensePeriodicWaterCheck();
     const PiezoState ps = piezoState();

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -35,6 +35,14 @@ void currentSenseInit(); void currentSenseTick();
 void currentSenseLogPlot(uint8_t); void currentSenseToggleScope();
 void currentSenseTogglePlotMute();
 float currentMeanMa(); float currentVarMa2();
+// Piezo-sense classifier (see piezo_sense.ino):
+PiezoState piezoState();
+float      piezoLastProbeMa();
+uint32_t   piezoWaterCountdownS();
+void       piezoResetForNewDock();
+void       piezoSensePeriodicWaterCheck();
+bool       piezoAutoProbeForDisc();
+float      piezoCalibrateWaterBaseline();
 // New in production firmware:
 void logInit();
 size_t logSnapshot(char*, size_t);
@@ -401,7 +409,17 @@ static void pollSerial() {
 // happen here, never inside the leaf modules.
 // ----------------------------------------------------------------------
 static void onContainerEvent(ContainerEvent ev) {
+  // When the user has configured current-sense as the dock detector, the reed
+  // switch's electrical state is irrelevant. piezoAutoProbeForDisc() in the
+  // main loop drives dock detection instead. Returning here keeps the reed
+  // hardware tolerated-but-ignored — no rip-out required.
+  if (cfg.senseUseAsReed) return;
+
   if (ev == ContainerEvent::Inserted) {
+    // Fresh dock — clear any lingering classifier state from the last run
+    // (countdown, fault). Sets g_piezoState=UNKNOWN; the first water probe
+    // in RUNNING will reclassify.
+    piezoResetForNewDock();
     // Docking always wins — from any state, including TRANSITION_FROM_RUNNING
     // mid-fade. enterRunning() is idempotent if we're already RUNNING.
     enterRunning();
@@ -412,6 +430,9 @@ static void onContainerEvent(ContainerEvent ev) {
     if (g_state == AppState::RUNNING) {
       enterTransitionFromRunning();
     }
+    // Reed-removal also clears any lingering piezo fault so a fresh dock
+    // probes against a clean slate.
+    piezoResetForNewDock();
   }
 }
 
@@ -601,6 +622,28 @@ void loop() {
   // Input edges + diagnostics
   onContainerEvent(containerPoll());
   onButtonEvent(buttonPoll());
+
+  // Piezo-sense classifier — two paths, mutually exclusive on senseUseAsReed.
+  //
+  // (1) RUNNING: periodic water-level probe. The function rate-limits itself
+  // to one probe per cfg.senseWaterCheckIntervalS, briefly forcing PWM to
+  // senseWaterProbeDuty for ~100 ms. If it classifies WATER_DEPLETED or
+  // DISC_DISCONNECTED, fade out via enterTransitionFromRunning().
+  //
+  // (2) IDLE + senseUseAsReed: auto-probe at PWM=10 every
+  // cfg.senseAutoProbeIntervalS to detect a fresh dock without the reed.
+  if (g_state == AppState::RUNNING) {
+    piezoSensePeriodicWaterCheck();
+    const PiezoState ps = piezoState();
+    if (ps == PiezoState::WATER_DEPLETED || ps == PiezoState::DISC_DISCONNECTED) {
+      Serial.println(ps == PiezoState::WATER_DEPLETED
+                       ? "[APP] water depleted — fading out"
+                       : "[APP] disc disconnected — fading out");
+      enterTransitionFromRunning();
+    }
+  } else if (g_state == AppState::IDLE && cfg.senseUseAsReed) {
+    if (piezoAutoProbeForDisc()) enterRunning();
+  }
 
   // D7 reflects container presence directly (dim when waiting for a dock,
   // off when docked) unless a web-UI override forces a specific state.

--- a/variants/block-kit/firmware/BlockKit_Production/config.h
+++ b/variants/block-kit/firmware/BlockKit_Production/config.h
@@ -52,6 +52,17 @@ struct Config {
   // --- Status LED (D7) ---
   uint8_t  statusLedDimDuty;
 
+  // --- Current-sense classifier (separate NVS keys; safe forward-compat) ---
+  uint8_t  senseProbeDuty;                  // PWM for disc-presence probe
+  uint16_t senseDiscPresentMa10x;           // threshold (mA × 10) above = disc present at probeDuty
+  uint8_t  senseWaterProbeDuty;             // PWM for water-level probe
+  uint16_t senseWaterLowMa10x;              // threshold below = low water at waterProbeDuty
+  uint16_t senseDiscDisconnMidMa10x;        // threshold below = disc snapped off mid-run
+  uint8_t  senseWaterHystMa10x;             // hysteresis added to senseWaterLowMa10x for recovery
+  uint16_t senseWaterCheckIntervalS;        // seconds between periodic water probes
+  uint16_t senseWaterShutdownS;             // seconds of low water before WATER_DEPLETED hard-stop
+  bool     senseUseAsReed;                  // future flag: bypass reed switch entirely (TBD)
+
   // --- Identity + secrets (separate NVS keys; NEVER returned by /api/config) ---
   char     hostname[CFG_HOSTNAME_MAX + 1];           // mDNS + ArduinoOTA hostname
   char     adminPasswordHash[CFG_SHA256_HEX_LEN + 1]; // sha256 hex of admin pwd

--- a/variants/block-kit/firmware/BlockKit_Production/config.h
+++ b/variants/block-kit/firmware/BlockKit_Production/config.h
@@ -61,7 +61,8 @@ struct Config {
   uint8_t  senseWaterHystMa10x;             // hysteresis added to senseWaterLowMa10x for recovery
   uint16_t senseWaterCheckIntervalS;        // seconds between periodic water probes
   uint16_t senseWaterShutdownS;             // seconds of low water before WATER_DEPLETED hard-stop
-  bool     senseUseAsReed;                  // future flag: bypass reed switch entirely (TBD)
+  bool     senseUseAsReed;                  // true = ignore reed switch, use auto-probe instead
+  uint16_t senseAutoProbeIntervalS;         // seconds between auto-probes when senseUseAsReed=true
 
   // --- Identity + secrets (separate NVS keys; NEVER returned by /api/config) ---
   char     hostname[CFG_HOSTNAME_MAX + 1];           // mDNS + ArduinoOTA hostname

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -25,6 +25,7 @@ static constexpr const char* KEY_SNS_WH   = "snsWh";    // water hysteresis (mA 
 static constexpr const char* KEY_SNS_WCI  = "snsWci";   // water check interval (s)
 static constexpr const char* KEY_SNS_WS   = "snsWs";    // water shutdown timeout (s)
 static constexpr const char* KEY_SNS_UAR  = "snsUar";   // useAsReed bool
+static constexpr const char* KEY_SNS_API  = "snsApi";   // auto-probe interval (s)
 
 Config cfg;
 
@@ -92,6 +93,7 @@ void configResetDefaults() {
   cfg.senseWaterCheckIntervalS   = CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S;
   cfg.senseWaterShutdownS        = CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S;
   cfg.senseUseAsReed             = CFG_DEFAULT_SENSE_USE_AS_REED;
+  cfg.senseAutoProbeIntervalS    = CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S;
   // Identity + secrets default to empty — first-boot setup populates them.
   strncpy(cfg.hostname, "mistmaker", CFG_HOSTNAME_MAX);
   cfg.hostname[CFG_HOSTNAME_MAX] = '\0';
@@ -217,6 +219,7 @@ void configInit() {
   cfg.senseWaterCheckIntervalS = p.getUShort(KEY_SNS_WCI, CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S);
   cfg.senseWaterShutdownS      = p.getUShort(KEY_SNS_WS,  CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S);
   cfg.senseUseAsReed           = p.getBool  (KEY_SNS_UAR, CFG_DEFAULT_SENSE_USE_AS_REED);
+  cfg.senseAutoProbeIntervalS  = p.getUShort(KEY_SNS_API, CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S);
 
   p.end();
 }
@@ -241,6 +244,7 @@ bool configSave() {
   p.putUShort(KEY_SNS_WCI, cfg.senseWaterCheckIntervalS);
   p.putUShort(KEY_SNS_WS,  cfg.senseWaterShutdownS);
   p.putBool  (KEY_SNS_UAR, cfg.senseUseAsReed);
+  p.putUShort(KEY_SNS_API, cfg.senseAutoProbeIntervalS);
   p.end();
   if (put != sizeof(blob)) {
     Serial.printf("[CFG] save failed: wrote %u / %u bytes\n",
@@ -356,6 +360,7 @@ bool configSetField(const char* name, long value) {
   SET_U16(senseWaterCheckIntervalS,  "senseWaterCheckIntervalS",  10, 3600);
   SET_U16(senseWaterShutdownS,       "senseWaterShutdownS",       30, 7200);
   SET_U8 (senseUseAsReed,            "senseUseAsReed",            0, 1);
+  SET_U16(senseAutoProbeIntervalS,   "senseAutoProbeIntervalS",   1, 3600);
   return false;  // unknown name
 }
 
@@ -411,6 +416,7 @@ size_t configToJson(char* out, size_t cap) {
   APPEND("\"senseWaterCheckIntervalS\":%u,", cfg.senseWaterCheckIntervalS);
   APPEND("\"senseWaterShutdownS\":%u,",      cfg.senseWaterShutdownS);
   APPEND("\"senseUseAsReed\":%u,",           cfg.senseUseAsReed ? 1 : 0);
+  APPEND("\"senseAutoProbeIntervalS\":%u,",  cfg.senseAutoProbeIntervalS);
   APPEND("\"hostname\":\"%s\"",          cfg.hostname);
   APPEND("}");
   return n;

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -14,6 +14,17 @@ static constexpr const char* KEY_BLOB = "cfg_v1";
 static constexpr const char* KEY_HOST     = "host";
 static constexpr const char* KEY_ADMIN_PW = "admin_pw";
 static constexpr const char* KEY_OTA_PW   = "ota_pw";
+// Current-sense fields — separate keys so they survive any future CfgBlob
+// version bump (same pattern as the secrets above).
+static constexpr const char* KEY_SNS_PD   = "snsPd";    // probe duty
+static constexpr const char* KEY_SNS_DP   = "snsDp";    // disc-present threshold (mA × 10)
+static constexpr const char* KEY_SNS_WPD  = "snsWpd";   // water probe duty
+static constexpr const char* KEY_SNS_WL   = "snsWl";    // water low threshold (mA × 10)
+static constexpr const char* KEY_SNS_DD   = "snsDd";    // disc-disconnect-mid-run threshold (mA × 10)
+static constexpr const char* KEY_SNS_WH   = "snsWh";    // water hysteresis (mA × 10)
+static constexpr const char* KEY_SNS_WCI  = "snsWci";   // water check interval (s)
+static constexpr const char* KEY_SNS_WS   = "snsWs";    // water shutdown timeout (s)
+static constexpr const char* KEY_SNS_UAR  = "snsUar";   // useAsReed bool
 
 Config cfg;
 
@@ -72,6 +83,15 @@ void configResetDefaults() {
   cfg.reedInsertDwellMs       = CFG_DEFAULT_REED_INSERT_DWELL_MS;
   cfg.reedRemoveDwellMs       = CFG_DEFAULT_REED_REMOVE_DWELL_MS;
   cfg.statusLedDimDuty        = CFG_DEFAULT_STATUS_LED_DIM_DUTY;
+  cfg.senseProbeDuty             = CFG_DEFAULT_SENSE_PROBE_DUTY;
+  cfg.senseDiscPresentMa10x      = CFG_DEFAULT_SENSE_DISC_PRESENT_MA10X;
+  cfg.senseWaterProbeDuty        = CFG_DEFAULT_SENSE_WATER_PROBE_DUTY;
+  cfg.senseWaterLowMa10x         = CFG_DEFAULT_SENSE_WATER_LOW_MA10X;
+  cfg.senseDiscDisconnMidMa10x   = CFG_DEFAULT_SENSE_DISC_DISCONN_MID_MA10X;
+  cfg.senseWaterHystMa10x        = CFG_DEFAULT_SENSE_WATER_HYST_MA10X;
+  cfg.senseWaterCheckIntervalS   = CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S;
+  cfg.senseWaterShutdownS        = CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S;
+  cfg.senseUseAsReed             = CFG_DEFAULT_SENSE_USE_AS_REED;
   // Identity + secrets default to empty — first-boot setup populates them.
   strncpy(cfg.hostname, "mistmaker", CFG_HOSTNAME_MAX);
   cfg.hostname[CFG_HOSTNAME_MAX] = '\0';
@@ -185,6 +205,19 @@ void configInit() {
   strncpy(cfg.otaPassword,        ota.c_str(),   CFG_OTA_PWD_MAX);
   cfg.otaPassword[CFG_OTA_PWD_MAX] = '\0';
 
+  // 3. Current-sense classifier fields. Each key defaults to the firmware
+  // default if absent, so an upgrade from a pre-classifier device picks up
+  // sensible values without an explicit migration step.
+  cfg.senseProbeDuty           = p.getUChar (KEY_SNS_PD,  CFG_DEFAULT_SENSE_PROBE_DUTY);
+  cfg.senseDiscPresentMa10x    = p.getUShort(KEY_SNS_DP,  CFG_DEFAULT_SENSE_DISC_PRESENT_MA10X);
+  cfg.senseWaterProbeDuty      = p.getUChar (KEY_SNS_WPD, CFG_DEFAULT_SENSE_WATER_PROBE_DUTY);
+  cfg.senseWaterLowMa10x       = p.getUShort(KEY_SNS_WL,  CFG_DEFAULT_SENSE_WATER_LOW_MA10X);
+  cfg.senseDiscDisconnMidMa10x = p.getUShort(KEY_SNS_DD,  CFG_DEFAULT_SENSE_DISC_DISCONN_MID_MA10X);
+  cfg.senseWaterHystMa10x      = p.getUChar (KEY_SNS_WH,  CFG_DEFAULT_SENSE_WATER_HYST_MA10X);
+  cfg.senseWaterCheckIntervalS = p.getUShort(KEY_SNS_WCI, CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S);
+  cfg.senseWaterShutdownS      = p.getUShort(KEY_SNS_WS,  CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S);
+  cfg.senseUseAsReed           = p.getBool  (KEY_SNS_UAR, CFG_DEFAULT_SENSE_USE_AS_REED);
+
   p.end();
 }
 
@@ -197,6 +230,17 @@ bool configSave() {
   CfgBlob blob;
   packBlob(blob);
   const size_t put = p.putBytes(KEY_BLOB, &blob, sizeof(blob));
+  // Sense fields live in their own NVS keys (outside the blob) so they
+  // survive any future CfgBlob version bump. Persist them alongside.
+  p.putUChar (KEY_SNS_PD,  cfg.senseProbeDuty);
+  p.putUShort(KEY_SNS_DP,  cfg.senseDiscPresentMa10x);
+  p.putUChar (KEY_SNS_WPD, cfg.senseWaterProbeDuty);
+  p.putUShort(KEY_SNS_WL,  cfg.senseWaterLowMa10x);
+  p.putUShort(KEY_SNS_DD,  cfg.senseDiscDisconnMidMa10x);
+  p.putUChar (KEY_SNS_WH,  cfg.senseWaterHystMa10x);
+  p.putUShort(KEY_SNS_WCI, cfg.senseWaterCheckIntervalS);
+  p.putUShort(KEY_SNS_WS,  cfg.senseWaterShutdownS);
+  p.putBool  (KEY_SNS_UAR, cfg.senseUseAsReed);
   p.end();
   if (put != sizeof(blob)) {
     Serial.printf("[CFG] save failed: wrote %u / %u bytes\n",
@@ -302,6 +346,16 @@ bool configSetField(const char* name, long value) {
   SET_U16(reedRemoveDwellMs,     "reedRemoveDwellMs",   0, 5000);
   // Status LED
   SET_U8 (statusLedDimDuty,      "statusLedDimDuty",    0, 255);
+  // Current-sense classifier — thresholds are mA × 10, so 110.0 mA = 1100.
+  SET_U8 (senseProbeDuty,            "senseProbeDuty",            0, 60);   // probe must stay below mist-effective level
+  SET_U16(senseDiscPresentMa10x,     "senseDiscPresentMa10x",     0, 5000);
+  SET_U8 (senseWaterProbeDuty,       "senseWaterProbeDuty",       0, 170);  // honor hardware safety cap
+  SET_U16(senseWaterLowMa10x,        "senseWaterLowMa10x",        0, 5000);
+  SET_U16(senseDiscDisconnMidMa10x,  "senseDiscDisconnMidMa10x",  0, 5000);
+  SET_U8 (senseWaterHystMa10x,       "senseWaterHystMa10x",       0, 250);
+  SET_U16(senseWaterCheckIntervalS,  "senseWaterCheckIntervalS",  10, 3600);
+  SET_U16(senseWaterShutdownS,       "senseWaterShutdownS",       30, 7200);
+  SET_U8 (senseUseAsReed,            "senseUseAsReed",            0, 1);
   return false;  // unknown name
 }
 
@@ -348,6 +402,15 @@ size_t configToJson(char* out, size_t cap) {
   APPEND("\"reedInsertDwellMs\":%u,",    cfg.reedInsertDwellMs);
   APPEND("\"reedRemoveDwellMs\":%u,",    cfg.reedRemoveDwellMs);
   APPEND("\"statusLedDimDuty\":%u,",     cfg.statusLedDimDuty);
+  APPEND("\"senseProbeDuty\":%u,",           cfg.senseProbeDuty);
+  APPEND("\"senseDiscPresentMa10x\":%u,",    cfg.senseDiscPresentMa10x);
+  APPEND("\"senseWaterProbeDuty\":%u,",      cfg.senseWaterProbeDuty);
+  APPEND("\"senseWaterLowMa10x\":%u,",       cfg.senseWaterLowMa10x);
+  APPEND("\"senseDiscDisconnMidMa10x\":%u,", cfg.senseDiscDisconnMidMa10x);
+  APPEND("\"senseWaterHystMa10x\":%u,",      cfg.senseWaterHystMa10x);
+  APPEND("\"senseWaterCheckIntervalS\":%u,", cfg.senseWaterCheckIntervalS);
+  APPEND("\"senseWaterShutdownS\":%u,",      cfg.senseWaterShutdownS);
+  APPEND("\"senseUseAsReed\":%u,",           cfg.senseUseAsReed ? 1 : 0);
   APPEND("\"hostname\":\"%s\"",          cfg.hostname);
   APPEND("}");
   return n;

--- a/variants/block-kit/firmware/BlockKit_Production/current_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/current_sense.ino
@@ -37,7 +37,8 @@ void currentSenseInit() {
 }
 
 // Convert a raw ADC count (0..4095, 0..3.3 V) to milliamps via INA180A3.
-static inline float adcToMa(uint16_t raw) {
+// Non-static so piezo_sense.ino can call it for its probe primitive.
+float adcToMa(uint16_t raw) {
   const float volts = (float(raw) * 3.3f) / 4095.0f;
   return (volts * 1000.0f) / CURRENT_SENSE_FACTOR;
 }

--- a/variants/block-kit/firmware/BlockKit_Production/mist.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/mist.ino
@@ -85,3 +85,20 @@ void mistEnable(bool enabled) {
 
 bool mistIsRunning()  { return g_mistBoostOn; }
 bool mistIsInhibited() { return g_mistInhibited; }
+
+// Engage boost rail for a piezo-sense probe without committing to a PWM level
+// via levelToDuty(). piezo_sense.ino writes the probe PWM directly with
+// ledcWrite() and needs the rail live to draw measurable current. Idempotent.
+// Caller MUST follow up with mistBoostOffForProbe() to release if not entering
+// RUNNING.
+void mistBoostOnForProbe() {
+  g_mistInhibited = false;
+  if (g_mistBoostOn) return;
+  digitalWrite(PIN_BOOST_EN, HIGH);
+  delayMicroseconds(500);
+  g_mistBoostOn = true;
+}
+
+void mistBoostOffForProbe() {
+  mistHardStop();
+}

--- a/variants/block-kit/firmware/BlockKit_Production/mist.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/mist.ino
@@ -86,11 +86,9 @@ void mistEnable(bool enabled) {
 bool mistIsRunning()  { return g_mistBoostOn; }
 bool mistIsInhibited() { return g_mistInhibited; }
 
-// Engage boost rail for a piezo-sense probe without committing to a PWM level
-// via levelToDuty(). piezo_sense.ino writes the probe PWM directly with
-// ledcWrite() and needs the rail live to draw measurable current. Idempotent.
-// Caller MUST follow up with mistBoostOffForProbe() to release if not entering
-// RUNNING.
+// Engage boost rail for a piezo-sense probe — piezo_sense writes the probe
+// PWM directly via ledcWrite() and needs the rail live to draw current.
+// Caller releases via mistBoostOffForProbe() if not entering RUNNING.
 void mistBoostOnForProbe() {
   g_mistInhibited = false;
   if (g_mistBoostOn) return;
@@ -99,6 +97,4 @@ void mistBoostOnForProbe() {
   g_mistBoostOn = true;
 }
 
-void mistBoostOffForProbe() {
-  mistHardStop();
-}
+void mistBoostOffForProbe() { mistHardStop(); }

--- a/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
@@ -11,6 +11,7 @@
 extern float adcToMa(uint16_t raw);
 extern void mistEnable(bool);
 extern bool mistIsInhibited();
+extern bool mistIsRunning();
 extern void mistBoostOnForProbe();
 extern void mistBoostOffForProbe();
 
@@ -90,17 +91,47 @@ static void classifyWaterReading(float ma) {
 }
 
 // Caller's responsibility to invoke only when state == RUNNING.
+//
+// Skips the probe if the boost rail isn't actually engaged — happens when the
+// user has set userLevel=0 in RUNNING (mist paused but state held). Probing
+// against a powered-down rail reads near-zero current and would falsely
+// classify a still-docked disc as DISC_DISCONNECTED.
 void piezoSensePeriodicWaterCheck() {
   const uint32_t now = millis();
   if (g_lastWaterCheckMs == 0) { g_lastWaterCheckMs = now; return; }
   if (now - g_lastWaterCheckMs < uint32_t(cfg.senseWaterCheckIntervalS) * 1000u) return;
   g_lastWaterCheckMs = now;
+  if (!mistIsRunning()) return;   // boost off — meaningful probe impossible
   classifyWaterReading(probeAtDuty(cfg.senseWaterProbeDuty, 50, 50));
 }
 
-// Called from the web "Calibrate water" button. Caller decides whether to
-// apply the recommended threshold via /api/config POST.
+// Fast disc-presence check during RUNNING — only relevant when senseUseAsReed
+// is enabled, since reed-removal events are ignored in that mode. Probes at
+// PWM=10 every senseAutoProbeIntervalS; below threshold → DISC_DISCONNECTED.
+// The main loop catches the state change and fades out. Less visible than the
+// water probe (PWM=10 vs 64) and much faster cadence than 60 s water checks.
+void piezoSensePeriodicDiscCheck() {
+  static uint32_t lastTickMs = 0;
+  const uint32_t now = millis();
+  if (lastTickMs == 0) { lastTickMs = now; return; }
+  if (now - lastTickMs < uint32_t(cfg.senseAutoProbeIntervalS) * 1000u) return;
+  lastTickMs = now;
+  if (!mistIsRunning()) return;   // mist paused — no meaningful read available
+  const float ma = probeAtDuty(cfg.senseProbeDuty, 30, 30);
+  const float thresh = float(cfg.senseDiscPresentMa10x) / 10.0f;
+  g_lastProbeMa = ma;
+  Serial.printf("[SENSE] removal-check: %.1f mA (thresh %.1f)\n", ma, thresh);
+  if (ma < thresh) g_piezoState = PiezoState::DISC_DISCONNECTED;
+}
+
+// Called from the web "Calibrate water" button. Returns 0.0 if the rail isn't
+// engaged (the caller — web handler — should reject and surface an error).
+// Caller decides whether to apply the recommended threshold via /api/config POST.
 float piezoCalibrateWaterBaseline() {
+  if (!mistIsRunning()) {
+    Serial.println("[SENSE] calibrate skipped — mist not running");
+    return 0.0f;
+  }
   const float ma = probeAtDuty(cfg.senseWaterProbeDuty, 100, 100);
   Serial.printf("[SENSE] calibrate: %.1f mA — recommended low threshold %.1f mA\n",
                 ma, ma * 0.85f);

--- a/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
@@ -1,49 +1,32 @@
 // Current-sense classifier for disc-presence and water-level detection.
 //
-// Two explicit probes drive a fixed PWM duty for a short window, sample
-// the ADC at full rate, and classify the mean current:
-//
-//   probeAtDuty(cfg.senseProbeDuty=10)        → above/below senseDiscPresentMa10x
-//                                              → DISC_PRESENT vs DISC_MISSING
-//   probeAtDuty(cfg.senseWaterProbeDuty=64)   → tri-class:
-//      < senseDiscDisconnMidMa10x  → DISC_DISCONNECTED (snapped off mid-run)
-//      < senseWaterLowMa10x        → WATER_LOW (start 5-min countdown)
-//      ≥ senseWaterLowMa10x + hyst → WATER_OK
-//
-// Disc-presence probe runs on every reed Inserted event (blocking ~150 ms,
-// invisible UX since the user just docked). Water-level probe runs every
-// cfg.senseWaterCheckIntervalS during RUNNING (blocking ~100 ms, briefly
-// holds mist at a fixed level — barely perceivable inside the wave's
-// natural ±duty variation).
+// Two probe types share probeAtDuty(): a low-PWM disc-presence probe used by
+// piezoAutoProbeForDisc() in reed-disabled mode, and a higher-PWM water-level
+// probe run every senseWaterCheckIntervalS during RUNNING. Reed-enabled mode
+// (default) skips disc-presence; the water probe still catches DISC_DISCONNECTED.
 
 #include "pins.h"
 #include "config.h"
 
-extern float adcToMa(uint16_t raw);   // defined in current_sense.ino
-
-// ---- Module state ----
-static PiezoState g_piezoState     = PiezoState::UNKNOWN;
-static float      g_lastProbeMa    = 0.0f;
-static uint32_t   g_lastWaterCheckMs = 0;
-static uint32_t   g_waterLowSinceMs  = 0;   // 0 = not in countdown
-
-// Forward decls of mist-driver primitives we need.
+extern float adcToMa(uint16_t raw);
 extern void mistEnable(bool);
 extern bool mistIsInhibited();
 extern void mistBoostOnForProbe();
 extern void mistBoostOffForProbe();
 
-// Public API ---------------------------------------------------------------
+static PiezoState g_piezoState     = PiezoState::UNKNOWN;
+static float      g_lastProbeMa    = 0.0f;
+static uint32_t   g_lastWaterCheckMs = 0;
+static uint32_t   g_waterLowSinceMs  = 0;   // 0 = no countdown active
 
-PiezoState piezoState()                  { return g_piezoState; }
-float      piezoLastProbeMa()            { return g_lastProbeMa; }
-uint32_t   piezoWaterLowSinceMs()        { return g_waterLowSinceMs; }
-void       piezoResetForNewDock()        { g_piezoState = PiezoState::UNKNOWN;
-                                           g_waterLowSinceMs = 0;
-                                           g_lastWaterCheckMs = 0; }
+PiezoState piezoState()       { return g_piezoState; }
+float      piezoLastProbeMa() { return g_lastProbeMa; }
+void       piezoResetForNewDock() {
+  g_piezoState = PiezoState::UNKNOWN;
+  g_waterLowSinceMs = 0;
+  g_lastWaterCheckMs = 0;
+}
 
-// Returns the seconds remaining in the WATER_LOW countdown, or 0 if no
-// countdown is active. Used by the status JSON and the UI.
 uint32_t piezoWaterCountdownS() {
   if (g_waterLowSinceMs == 0) return 0;
   const uint32_t elapsed = millis() - g_waterLowSinceMs;
@@ -52,21 +35,14 @@ uint32_t piezoWaterCountdownS() {
   return (window - elapsed) / 1000u;
 }
 
-// Probe primitive: drive PWM at `duty` for settleMs + sampleMs, sample
-// ADC during the sample window, return mean current in mA.
-//
-// Caller MUST have the boost rail engaged (i.e. mistEnable(true) earlier
-// in the flow). We don't manipulate the boost here so back-to-back probes
-// don't cycle the rail unnecessarily.
-//
-// Total time blocking: settleMs + sampleMs. analogRead on ESP32-C6 takes
-// ~3-4 us, so we get ~250-300 samples per ms of sampleMs.
+// Drive PWM at `duty` for settleMs, then sample ADC for sampleMs and return
+// mean mA. Caller is responsible for the boost rail being engaged — we don't
+// cycle it here so back-to-back probes don't churn the converter.
 static float probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs) {
-  if (mistIsInhibited()) return 0.0f;  // boost rail not engaged — meaningless probe
+  if (mistIsInhibited()) return 0.0f;
   ledcWrite(PIN_MIST_PWM, duty);
   delay(settleMs);
-  uint32_t sum = 0;
-  uint32_t count = 0;
+  uint32_t sum = 0, count = 0;
   const uint32_t startMs = millis();
   while (millis() - startMs < sampleMs) {
     sum += analogRead(PIN_CURRENT_ADC);
@@ -76,28 +52,8 @@ static float probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs) {
   return adcToMa(uint16_t(sum / count));
 }
 
-// Disc-presence probe — called from enterRunning() right after mistEnable.
-// Blocks ~150 ms (100 ms settle + 50 ms sample). Sets g_piezoState.
-// Returns true if disc was detected (caller should proceed with mist);
-// false to abort (caller should NOT engage mist).
-bool piezoSenseProbeOnInsert() {
-  // Boost rail must be on; enterRunning() called mistEnable(true) before us.
-  g_lastProbeMa = probeAtDuty(cfg.senseProbeDuty, 100, 50);
-  const float thresh = float(cfg.senseDiscPresentMa10x) / 10.0f;
-  Serial.printf("[SENSE] disc probe: %.1f mA at PWM=%u (threshold %.1f mA)\n",
-                g_lastProbeMa, cfg.senseProbeDuty, thresh);
-  if (g_lastProbeMa >= thresh) {
-    g_piezoState = PiezoState::WATER_OK;   // optimistic until first water probe says otherwise
-    return true;
-  }
-  g_piezoState = PiezoState::DISC_MISSING;
-  Serial.println("[SENSE] disc missing — refusing to engage mist");
-  return false;
-}
-
-// Classify a water-level probe reading. Mutates g_piezoState and the
-// countdown timer. Called from piezoSensePeriodicWaterCheck() AND from
-// piezoCalibrateWaterBaseline() so the threshold logic lives in one place.
+// Threshold logic lives here so it's shared between the periodic probe and the
+// calibrate-now path. Mutates g_piezoState + the countdown timer.
 static void classifyWaterReading(float ma) {
   g_lastProbeMa = ma;
   const float discDisconn = float(cfg.senseDiscDisconnMidMa10x) / 10.0f;
@@ -107,28 +63,25 @@ static void classifyWaterReading(float ma) {
   if (ma < discDisconn) {
     g_piezoState = PiezoState::DISC_DISCONNECTED;
     g_waterLowSinceMs = 0;
-    Serial.printf("[SENSE] DISC_DISCONNECTED — current %.1f mA < %.1f mA\n", ma, discDisconn);
+    Serial.printf("[SENSE] DISC_DISCONNECTED — %.1f mA < %.1f\n", ma, discDisconn);
     return;
   }
   if (ma < waterLow) {
     if (g_piezoState != PiezoState::WATER_LOW && g_piezoState != PiezoState::WATER_DEPLETED) {
-      g_waterLowSinceMs = millis();   // start countdown
-      Serial.printf("[SENSE] WATER_LOW — countdown to shutdown begins (%.1f mA)\n", ma);
+      g_waterLowSinceMs = millis();
+      Serial.printf("[SENSE] WATER_LOW — countdown begins (%.1f mA)\n", ma);
     }
-    // Check countdown expiry.
     if (g_waterLowSinceMs > 0 &&
         millis() - g_waterLowSinceMs >= uint32_t(cfg.senseWaterShutdownS) * 1000u) {
       g_piezoState = PiezoState::WATER_DEPLETED;
-      Serial.println("[SENSE] WATER_DEPLETED — countdown expired, mist will hard-stop");
+      Serial.println("[SENSE] WATER_DEPLETED — countdown expired");
     } else {
       g_piezoState = PiezoState::WATER_LOW;
     }
     return;
   }
-  // ma >= waterLow. Apply hysteresis: only recover if comfortably above.
-  if (g_piezoState == PiezoState::WATER_LOW && ma < (waterLow + hyst)) {
-    return;  // stay LOW, don't flap
-  }
+  // ma >= waterLow. Hysteresis: don't flap back to OK until comfortably above.
+  if (g_piezoState == PiezoState::WATER_LOW && ma < (waterLow + hyst)) return;
   if (g_piezoState != PiezoState::WATER_OK) {
     Serial.printf("[SENSE] WATER_OK (%.1f mA)\n", ma);
   }
@@ -136,45 +89,29 @@ static void classifyWaterReading(float ma) {
   g_waterLowSinceMs = 0;
 }
 
-// Periodic water-level check — called from loop(). Returns early most of
-// the time; once per cfg.senseWaterCheckIntervalS does a brief probe at
-// senseWaterProbeDuty.
-//
-// Should only be invoked when state == RUNNING (caller's responsibility).
+// Caller's responsibility to invoke only when state == RUNNING.
 void piezoSensePeriodicWaterCheck() {
   const uint32_t now = millis();
-  // First call after entering RUNNING — schedule next, no probe yet.
   if (g_lastWaterCheckMs == 0) { g_lastWaterCheckMs = now; return; }
   if (now - g_lastWaterCheckMs < uint32_t(cfg.senseWaterCheckIntervalS) * 1000u) return;
   g_lastWaterCheckMs = now;
-  const float ma = probeAtDuty(cfg.senseWaterProbeDuty, 50, 50);
-  classifyWaterReading(ma);
+  classifyWaterReading(probeAtDuty(cfg.senseWaterProbeDuty, 50, 50));
 }
 
-// "Calibrate now" — user clicks the button in the web UI while the device
-// is in a known-good state (water present, mist running normally). We
-// probe at senseWaterProbeDuty, record the reading, and recommend a new
-// low-water threshold at 85% of recorded. Returns the recorded mA.
+// Called from the web "Calibrate water" button. Caller decides whether to
+// apply the recommended threshold via /api/config POST.
 float piezoCalibrateWaterBaseline() {
   const float ma = probeAtDuty(cfg.senseWaterProbeDuty, 100, 100);
-  Serial.printf("[SENSE] calibrate: %.1f mA at PWM=%u — recommended low threshold %.1f mA\n",
-                ma, cfg.senseWaterProbeDuty, ma * 0.85f);
-  // Caller decides whether to apply via /api/config POST.
+  Serial.printf("[SENSE] calibrate: %.1f mA — recommended low threshold %.1f mA\n",
+                ma, ma * 0.85f);
   return ma;
 }
 
-// Auto-probe for disc presence in IDLE — used only when cfg.senseUseAsReed=true
-// (i.e. the user has chosen current-sense as the dock detector instead of the
-// reed switch). Rate-limited internally to one probe per senseAutoProbeIntervalS.
-//
-// Returns true when a fresh disc is detected and the caller should enterRunning().
-// On true return, the boost rail is LEFT ENGAGED so the main loop's smoother
-// can take over without a re-settle gap.
-//
-// Post-fault handling: if the module is in WATER_DEPLETED or DISC_DISCONNECTED,
-// a probe that comes back below the disc-present threshold is interpreted as
-// the user lifting the dispenser (clearing the fault). The next probe with a
-// disc present will then re-enter RUNNING normally.
+// Auto-probe for disc presence in IDLE — used only when cfg.senseUseAsReed=true.
+// Returns true when a fresh disc is detected; caller should enterRunning(). On
+// true return, the boost rail is LEFT ENGAGED so the smoother can take over
+// without a re-settle gap. In a fault state (WATER_DEPLETED / DISC_DISCONNECTED)
+// a probe with no disc clears the fault — the user lifted the dispenser.
 bool piezoAutoProbeForDisc() {
   static uint32_t lastTickMs = 0;
   const uint32_t now = millis();
@@ -190,14 +127,12 @@ bool piezoAutoProbeForDisc() {
   const bool present = (ma >= thresh);
   g_lastProbeMa = ma;
 
-  Serial.printf("[SENSE] auto-probe: %.1f mA (threshold %.1f, fault=%d, present=%d)\n",
+  Serial.printf("[SENSE] auto-probe: %.1f mA (thresh %.1f, fault=%d, present=%d)\n",
                 ma, thresh, int(inFault), int(present));
 
   if (inFault) {
-    // Stay in fault until user lifts (probe sees no disc). Then reset so a
-    // future re-dock with fresh water can resume normally.
     if (!present) {
-      Serial.println("[SENSE] post-fault lift detected — ready for redock");
+      Serial.println("[SENSE] post-fault lift detected");
       piezoResetForNewDock();
     }
     mistBoostOffForProbe();
@@ -206,9 +141,7 @@ bool piezoAutoProbeForDisc() {
 
   if (present) {
     g_piezoState = PiezoState::WATER_OK;   // optimistic until first water probe
-    // Boost stays ON — caller's enterRunning() + smoother will drive duty
-    // up from PWM=10 to the operating point without a rail gap.
-    return true;
+    return true;                            // boost stays on for the smoother
   }
   g_piezoState = PiezoState::DISC_MISSING;
   mistBoostOffForProbe();

--- a/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
@@ -1,0 +1,162 @@
+// Current-sense classifier for disc-presence and water-level detection.
+//
+// Two explicit probes drive a fixed PWM duty for a short window, sample
+// the ADC at full rate, and classify the mean current:
+//
+//   probeAtDuty(cfg.senseProbeDuty=10)        → above/below senseDiscPresentMa10x
+//                                              → DISC_PRESENT vs DISC_MISSING
+//   probeAtDuty(cfg.senseWaterProbeDuty=64)   → tri-class:
+//      < senseDiscDisconnMidMa10x  → DISC_DISCONNECTED (snapped off mid-run)
+//      < senseWaterLowMa10x        → WATER_LOW (start 5-min countdown)
+//      ≥ senseWaterLowMa10x + hyst → WATER_OK
+//
+// Disc-presence probe runs on every reed Inserted event (blocking ~150 ms,
+// invisible UX since the user just docked). Water-level probe runs every
+// cfg.senseWaterCheckIntervalS during RUNNING (blocking ~100 ms, briefly
+// holds mist at a fixed level — barely perceivable inside the wave's
+// natural ±duty variation).
+
+#include "pins.h"
+#include "config.h"
+
+extern float adcToMa(uint16_t raw);   // defined in current_sense.ino
+
+// ---- Module state ----
+static PiezoState g_piezoState     = PiezoState::UNKNOWN;
+static float      g_lastProbeMa    = 0.0f;
+static uint32_t   g_lastWaterCheckMs = 0;
+static uint32_t   g_waterLowSinceMs  = 0;   // 0 = not in countdown
+
+// Forward decls of mist-driver primitives we need.
+extern void mistEnable(bool);
+extern bool mistIsInhibited();
+
+// Public API ---------------------------------------------------------------
+
+PiezoState piezoState()                  { return g_piezoState; }
+float      piezoLastProbeMa()            { return g_lastProbeMa; }
+uint32_t   piezoWaterLowSinceMs()        { return g_waterLowSinceMs; }
+void       piezoResetForNewDock()        { g_piezoState = PiezoState::UNKNOWN;
+                                           g_waterLowSinceMs = 0;
+                                           g_lastWaterCheckMs = 0; }
+
+// Returns the seconds remaining in the WATER_LOW countdown, or 0 if no
+// countdown is active. Used by the status JSON and the UI.
+uint32_t piezoWaterCountdownS() {
+  if (g_waterLowSinceMs == 0) return 0;
+  const uint32_t elapsed = millis() - g_waterLowSinceMs;
+  const uint32_t window  = uint32_t(cfg.senseWaterShutdownS) * 1000u;
+  if (elapsed >= window) return 0;
+  return (window - elapsed) / 1000u;
+}
+
+// Probe primitive: drive PWM at `duty` for settleMs + sampleMs, sample
+// ADC during the sample window, return mean current in mA.
+//
+// Caller MUST have the boost rail engaged (i.e. mistEnable(true) earlier
+// in the flow). We don't manipulate the boost here so back-to-back probes
+// don't cycle the rail unnecessarily.
+//
+// Total time blocking: settleMs + sampleMs. analogRead on ESP32-C6 takes
+// ~3-4 us, so we get ~250-300 samples per ms of sampleMs.
+static float probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs) {
+  if (mistIsInhibited()) return 0.0f;  // boost rail not engaged — meaningless probe
+  ledcWrite(PIN_MIST_PWM, duty);
+  delay(settleMs);
+  uint32_t sum = 0;
+  uint32_t count = 0;
+  const uint32_t startMs = millis();
+  while (millis() - startMs < sampleMs) {
+    sum += analogRead(PIN_CURRENT_ADC);
+    count++;
+  }
+  if (count == 0) return 0.0f;
+  return adcToMa(uint16_t(sum / count));
+}
+
+// Disc-presence probe — called from enterRunning() right after mistEnable.
+// Blocks ~150 ms (100 ms settle + 50 ms sample). Sets g_piezoState.
+// Returns true if disc was detected (caller should proceed with mist);
+// false to abort (caller should NOT engage mist).
+bool piezoSenseProbeOnInsert() {
+  // Boost rail must be on; enterRunning() called mistEnable(true) before us.
+  g_lastProbeMa = probeAtDuty(cfg.senseProbeDuty, 100, 50);
+  const float thresh = float(cfg.senseDiscPresentMa10x) / 10.0f;
+  Serial.printf("[SENSE] disc probe: %.1f mA at PWM=%u (threshold %.1f mA)\n",
+                g_lastProbeMa, cfg.senseProbeDuty, thresh);
+  if (g_lastProbeMa >= thresh) {
+    g_piezoState = PiezoState::WATER_OK;   // optimistic until first water probe says otherwise
+    return true;
+  }
+  g_piezoState = PiezoState::DISC_MISSING;
+  Serial.println("[SENSE] disc missing — refusing to engage mist");
+  return false;
+}
+
+// Classify a water-level probe reading. Mutates g_piezoState and the
+// countdown timer. Called from piezoSensePeriodicWaterCheck() AND from
+// piezoCalibrateWaterBaseline() so the threshold logic lives in one place.
+static void classifyWaterReading(float ma) {
+  g_lastProbeMa = ma;
+  const float discDisconn = float(cfg.senseDiscDisconnMidMa10x) / 10.0f;
+  const float waterLow    = float(cfg.senseWaterLowMa10x)       / 10.0f;
+  const float hyst        = float(cfg.senseWaterHystMa10x)      / 10.0f;
+
+  if (ma < discDisconn) {
+    g_piezoState = PiezoState::DISC_DISCONNECTED;
+    g_waterLowSinceMs = 0;
+    Serial.printf("[SENSE] DISC_DISCONNECTED — current %.1f mA < %.1f mA\n", ma, discDisconn);
+    return;
+  }
+  if (ma < waterLow) {
+    if (g_piezoState != PiezoState::WATER_LOW && g_piezoState != PiezoState::WATER_DEPLETED) {
+      g_waterLowSinceMs = millis();   // start countdown
+      Serial.printf("[SENSE] WATER_LOW — countdown to shutdown begins (%.1f mA)\n", ma);
+    }
+    // Check countdown expiry.
+    if (g_waterLowSinceMs > 0 &&
+        millis() - g_waterLowSinceMs >= uint32_t(cfg.senseWaterShutdownS) * 1000u) {
+      g_piezoState = PiezoState::WATER_DEPLETED;
+      Serial.println("[SENSE] WATER_DEPLETED — countdown expired, mist will hard-stop");
+    } else {
+      g_piezoState = PiezoState::WATER_LOW;
+    }
+    return;
+  }
+  // ma >= waterLow. Apply hysteresis: only recover if comfortably above.
+  if (g_piezoState == PiezoState::WATER_LOW && ma < (waterLow + hyst)) {
+    return;  // stay LOW, don't flap
+  }
+  if (g_piezoState != PiezoState::WATER_OK) {
+    Serial.printf("[SENSE] WATER_OK (%.1f mA)\n", ma);
+  }
+  g_piezoState = PiezoState::WATER_OK;
+  g_waterLowSinceMs = 0;
+}
+
+// Periodic water-level check — called from loop(). Returns early most of
+// the time; once per cfg.senseWaterCheckIntervalS does a brief probe at
+// senseWaterProbeDuty.
+//
+// Should only be invoked when state == RUNNING (caller's responsibility).
+void piezoSensePeriodicWaterCheck() {
+  const uint32_t now = millis();
+  // First call after entering RUNNING — schedule next, no probe yet.
+  if (g_lastWaterCheckMs == 0) { g_lastWaterCheckMs = now; return; }
+  if (now - g_lastWaterCheckMs < uint32_t(cfg.senseWaterCheckIntervalS) * 1000u) return;
+  g_lastWaterCheckMs = now;
+  const float ma = probeAtDuty(cfg.senseWaterProbeDuty, 50, 50);
+  classifyWaterReading(ma);
+}
+
+// "Calibrate now" — user clicks the button in the web UI while the device
+// is in a known-good state (water present, mist running normally). We
+// probe at senseWaterProbeDuty, record the reading, and recommend a new
+// low-water threshold at 85% of recorded. Returns the recorded mA.
+float piezoCalibrateWaterBaseline() {
+  const float ma = probeAtDuty(cfg.senseWaterProbeDuty, 100, 100);
+  Serial.printf("[SENSE] calibrate: %.1f mA at PWM=%u — recommended low threshold %.1f mA\n",
+                ma, cfg.senseWaterProbeDuty, ma * 0.85f);
+  // Caller decides whether to apply via /api/config POST.
+  return ma;
+}

--- a/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
@@ -30,6 +30,8 @@ static uint32_t   g_waterLowSinceMs  = 0;   // 0 = not in countdown
 // Forward decls of mist-driver primitives we need.
 extern void mistEnable(bool);
 extern bool mistIsInhibited();
+extern void mistBoostOnForProbe();
+extern void mistBoostOffForProbe();
 
 // Public API ---------------------------------------------------------------
 
@@ -159,4 +161,56 @@ float piezoCalibrateWaterBaseline() {
                 ma, cfg.senseWaterProbeDuty, ma * 0.85f);
   // Caller decides whether to apply via /api/config POST.
   return ma;
+}
+
+// Auto-probe for disc presence in IDLE — used only when cfg.senseUseAsReed=true
+// (i.e. the user has chosen current-sense as the dock detector instead of the
+// reed switch). Rate-limited internally to one probe per senseAutoProbeIntervalS.
+//
+// Returns true when a fresh disc is detected and the caller should enterRunning().
+// On true return, the boost rail is LEFT ENGAGED so the main loop's smoother
+// can take over without a re-settle gap.
+//
+// Post-fault handling: if the module is in WATER_DEPLETED or DISC_DISCONNECTED,
+// a probe that comes back below the disc-present threshold is interpreted as
+// the user lifting the dispenser (clearing the fault). The next probe with a
+// disc present will then re-enter RUNNING normally.
+bool piezoAutoProbeForDisc() {
+  static uint32_t lastTickMs = 0;
+  const uint32_t now = millis();
+  if (now - lastTickMs < uint32_t(cfg.senseAutoProbeIntervalS) * 1000u) return false;
+  lastTickMs = now;
+
+  const bool inFault = (g_piezoState == PiezoState::WATER_DEPLETED ||
+                        g_piezoState == PiezoState::DISC_DISCONNECTED);
+
+  mistBoostOnForProbe();
+  const float ma = probeAtDuty(cfg.senseProbeDuty, 100, 50);
+  const float thresh = float(cfg.senseDiscPresentMa10x) / 10.0f;
+  const bool present = (ma >= thresh);
+  g_lastProbeMa = ma;
+
+  Serial.printf("[SENSE] auto-probe: %.1f mA (threshold %.1f, fault=%d, present=%d)\n",
+                ma, thresh, int(inFault), int(present));
+
+  if (inFault) {
+    // Stay in fault until user lifts (probe sees no disc). Then reset so a
+    // future re-dock with fresh water can resume normally.
+    if (!present) {
+      Serial.println("[SENSE] post-fault lift detected — ready for redock");
+      piezoResetForNewDock();
+    }
+    mistBoostOffForProbe();
+    return false;
+  }
+
+  if (present) {
+    g_piezoState = PiezoState::WATER_OK;   // optimistic until first water probe
+    // Boost stays ON — caller's enterRunning() + smoother will drive duty
+    // up from PWM=10 to the operating point without a rail gap.
+    return true;
+  }
+  g_piezoState = PiezoState::DISC_MISSING;
+  mistBoostOffForProbe();
+  return false;
 }

--- a/variants/block-kit/firmware/BlockKit_Production/pins.h
+++ b/variants/block-kit/firmware/BlockKit_Production/pins.h
@@ -194,3 +194,15 @@ enum class ButtonEvent : uint8_t {
   LongPressTick,
   LongPressEnd,
 };
+
+// Piezo health states from the current-sense classifier (orthogonal to AppState).
+// Set by piezo_sense.ino, surfaced in /api/status and the web UI status pill.
+enum class PiezoState : uint8_t {
+  UNKNOWN,           // before first probe (boot, idle pre-dock)
+  DISC_MISSING,      // probe on dock returned current below disc-present threshold
+  DISC_DRY,          // disc present at PWM=10 but water-level probe says dry (rare)
+  WATER_OK,          // last water probe was above threshold — normal operation
+  WATER_LOW,         // last water probe below threshold — countdown active
+  WATER_DEPLETED,    // countdown expired — mist hard-stopped, awaiting container lift
+  DISC_DISCONNECTED, // disc snapped off mid-run — hard-stopped immediately
+};

--- a/variants/block-kit/firmware/BlockKit_Production/pins.h
+++ b/variants/block-kit/firmware/BlockKit_Production/pins.h
@@ -152,6 +152,19 @@ constexpr uint16_t CFG_DEFAULT_REED_REMOVE_DWELL_MS  = 100;
 // Status LED (D7)
 constexpr uint8_t  CFG_DEFAULT_STATUS_LED_DIM_DUTY   = 24;    // ~10 %
 
+// Current-sense classifier — disc-presence + water-level detection.
+// Bench numbers per David's 2026-05-15 measurements (XIAO ESP32-C6 + INA180A3
+// + 30 mΩ shunt). Stored as uint16_t × 10 in NVS so 0.1 mA precision survives.
+constexpr uint8_t  CFG_DEFAULT_SENSE_PROBE_DUTY              = 10;    // PWM for disc-presence probe
+constexpr uint16_t CFG_DEFAULT_SENSE_DISC_PRESENT_MA10X      = 100;   // 10.0 mA — above = disc present at PWM=10
+constexpr uint8_t  CFG_DEFAULT_SENSE_WATER_PROBE_DUTY        = 64;    // PWM for water-level probe
+constexpr uint16_t CFG_DEFAULT_SENSE_WATER_LOW_MA10X         = 1100;  // 110.0 mA — below = water low at PWM=64
+constexpr uint16_t CFG_DEFAULT_SENSE_DISC_DISCONN_MID_MA10X  = 700;   // 70.0 mA — below at PWM=64 means disc fell off
+constexpr uint8_t  CFG_DEFAULT_SENSE_WATER_HYST_MA10X        = 50;    // 5.0 mA hysteresis on recovery
+constexpr uint16_t CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S  = 60;    // seconds between water probes
+constexpr uint16_t CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S        = 300;   // 5 min countdown before WATER_DEPLETED
+constexpr bool     CFG_DEFAULT_SENSE_USE_AS_REED             = false; // true = ignore reed switch (TBD)
+
 // ---------- Top-level state machine ----------
 //
 // Three container-driven states, plus an orthogonal `g_ledsHidden` boolean

--- a/variants/block-kit/firmware/BlockKit_Production/pins.h
+++ b/variants/block-kit/firmware/BlockKit_Production/pins.h
@@ -163,7 +163,8 @@ constexpr uint16_t CFG_DEFAULT_SENSE_DISC_DISCONN_MID_MA10X  = 700;   // 70.0 mA
 constexpr uint8_t  CFG_DEFAULT_SENSE_WATER_HYST_MA10X        = 50;    // 5.0 mA hysteresis on recovery
 constexpr uint16_t CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S  = 60;    // seconds between water probes
 constexpr uint16_t CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S        = 300;   // 5 min countdown before WATER_DEPLETED
-constexpr bool     CFG_DEFAULT_SENSE_USE_AS_REED             = false; // true = ignore reed switch (TBD)
+constexpr bool     CFG_DEFAULT_SENSE_USE_AS_REED             = false; // true = ignore reed switch, auto-probe instead
+constexpr uint16_t CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S    = 5;     // auto-probe interval in IDLE when senseUseAsReed=true
 
 // ---------- Top-level state machine ----------
 //

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -9,6 +9,8 @@
 //   POST /api/cmd/leds      toggle hide/show LED ring (mist unaffected)
 //   POST /api/cmd/scope     toggle scope mode
 //   POST /api/cmd/plotmute  toggle [PLOT] CSV stream mute
+//   POST /api/cmd/calibrate-water  capture current at water-probe duty,
+//                                  return recorded mA + recommended low threshold
 //   POST /api/cmd/level     set runtime userLevel; body = {"value":0..255}
 //   POST /api/cmd/state     force state idle/running; body = {"state":"..."}
 //   POST /api/cmd/statled   override indicator LED; body = {"mode":"auto|on|off"}
@@ -123,6 +125,19 @@ static const char* webStateName(AppState s) {
   return "?";
 }
 
+static const char* piezoStateName(PiezoState s) {
+  switch (s) {
+    case PiezoState::UNKNOWN:           return "UNKNOWN";
+    case PiezoState::DISC_MISSING:      return "DISC_MISSING";
+    case PiezoState::DISC_DRY:          return "DISC_DRY";
+    case PiezoState::WATER_OK:          return "WATER_OK";
+    case PiezoState::WATER_LOW:         return "WATER_LOW";
+    case PiezoState::WATER_DEPLETED:    return "WATER_DEPLETED";
+    case PiezoState::DISC_DISCONNECTED: return "DISC_DISCONNECTED";
+  }
+  return "?";
+}
+
 static size_t buildStatusJson(char* out, size_t cap) {
   return snprintf(out, cap,
     "{\"state\":\"%s\","
@@ -137,6 +152,9 @@ static size_t buildStatusJson(char* out, size_t cap) {
     "\"currentLevel\":%u,"
     "\"meanMa\":%.1f,"
     "\"varMa2\":%.1f,"
+    "\"piezoState\":\"%s\","
+    "\"piezoProbeMa\":%.1f,"
+    "\"waterCountdownS\":%lu,"
     "\"uptimeMs\":%lu,"
     "\"freeHeap\":%u,"
     "\"rssi\":%d,"
@@ -153,6 +171,9 @@ static size_t buildStatusJson(char* out, size_t cap) {
     appCurrentLevel(),
     currentMeanMa(),
     currentVarMa2(),
+    piezoStateName(piezoState()),
+    piezoLastProbeMa(),
+    (unsigned long)piezoWaterCountdownS(),
     (unsigned long)millis(),
     unsigned(ESP.getFreeHeap()),
     (int)WiFi.RSSI(),
@@ -206,7 +227,7 @@ static void handleRoot() {
 }
 
 static void handleStatus() {
-  char buf[512];
+  char buf[640];
   buildStatusJson(buf, sizeof(buf));
   g_http.sendHeader("Cache-Control", "no-store");
   g_http.send(200, "application/json", buf);
@@ -302,6 +323,21 @@ static void handleCmdPlotMute() {
   if (!requireAuth()) return;
   currentSenseTogglePlotMute();
   g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// "Calibrate now" — capture current at senseWaterProbeDuty as the water-OK
+// baseline. The user clicks this when the device is in a known-good state
+// (water present, mist running). Returns the recorded mA and a recommended
+// low-water threshold (recorded × 0.85). Caller (UI) decides whether to
+// apply via /api/config POST.
+static void handleCmdCalibrateWater() {
+  if (!requireAuth()) return;
+  const float ma = piezoCalibrateWaterBaseline();
+  char body[128];
+  snprintf(body, sizeof(body),
+           "{\"ok\":true,\"recordedMa\":%.1f,\"recommendedLowMa\":%.1f}",
+           ma, ma * 0.85f);
+  g_http.send(200, "application/json", body);
 }
 
 // Live level set — mirrors serial 'vN'. Body: {"value": 0..255}.
@@ -430,7 +466,7 @@ static void handleEvents() {
   g_sseClient.println();
   g_sseClient.flush();
   // Immediate first frame so the UI populates without waiting 250 ms.
-  char buf[512];
+  char buf[640];
   const size_t n = buildStatusJson(buf, sizeof(buf));
   g_sseClient.print("data: ");
   g_sseClient.write((const uint8_t*)buf, n);
@@ -447,7 +483,7 @@ static void sseTick() {
   const uint32_t now = millis();
   if (now - g_lastSseMs < SSE_INTERVAL_MS) return;
   g_lastSseMs = now;
-  char buf[512];
+  char buf[640];
   const size_t n = buildStatusJson(buf, sizeof(buf));
   // SSE wire format: `data: <line>\n\n`. Each loop iteration sends one frame.
   g_sseClient.print("data: ");
@@ -476,6 +512,7 @@ void webInit() {
   g_http.on("/api/cmd/leds",        HTTP_POST, handleCmdLeds);
   g_http.on("/api/cmd/scope",       HTTP_POST, handleCmdScope);
   g_http.on("/api/cmd/plotmute",    HTTP_POST, handleCmdPlotMute);
+  g_http.on("/api/cmd/calibrate-water", HTTP_POST, handleCmdCalibrateWater);
   g_http.on("/api/cmd/level",       HTTP_POST, handleCmdLevel);
   g_http.on("/api/cmd/state",       HTTP_POST, handleCmdState);
   g_http.on("/api/cmd/statled",     HTTP_POST, handleCmdStatLed);

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -327,12 +327,24 @@ static void handleCmdPlotMute() {
 
 // "Calibrate now" — capture current at senseWaterProbeDuty as the water-OK
 // baseline. The user clicks this when the device is in a known-good state
-// (water present, mist running). Returns the recorded mA and a recommended
-// low-water threshold (recorded × 0.85). Caller (UI) decides whether to
-// apply via /api/config POST.
+// (water present, mist running). Rejects with 409 if state isn't RUNNING or
+// the boost rail is off (probe would read ~0 mA and we'd recommend a
+// disabling-low threshold). Returns the recorded mA + recommended low-water
+// threshold (recorded × 0.85) on success; UI decides whether to apply via
+// /api/config POST.
 static void handleCmdCalibrateWater() {
   if (!requireAuth()) return;
+  if (appCurrentState() != AppState::RUNNING || !mistIsRunning()) {
+    g_http.send(409, "application/json",
+                "{\"error\":\"calibrate requires RUNNING with mist actively flowing\"}");
+    return;
+  }
   const float ma = piezoCalibrateWaterBaseline();
+  if (ma <= 0.0f) {
+    g_http.send(409, "application/json",
+                "{\"error\":\"probe returned ~0 mA — check that water + disc are present\"}");
+    return;
+  }
   char body[128];
   snprintf(body, sizeof(body),
            "{\"ok\":true,\"recordedMa\":%.1f,\"recommendedLowMa\":%.1f}",

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -184,6 +184,11 @@ details.adv>div{padding:0 14px 14px}
       <button class="btn mini ghost" id="bStLOn">On</button>
       <button class="btn mini ghost" id="bStLOff">Off</button>
     </div>
+    <div class="grp"><span class="name">Piezo</span>
+      <span class="val" id="pPiezo">-</span>
+      <span class="val" id="pPiezoMa" style="color:var(--mut);font-size:.85em">-</span>
+      <button class="btn mini ghost" id="bCalWater" title="Run a probe at the water-level PWM and use the result to recommend a low-water threshold. Best while mist is running with water present.">Calibrate water</button>
+    </div>
   </div>
 
   <!-- Mist pulse depth (friendly wrapper around cfg.mistWaveTroughQ8) -->
@@ -336,6 +341,18 @@ const FIELDS=[
  {grp:"Status LED (D7)",f:[
   ["statusLedDimDuty","Dim duty (0..255)",0,255,1],
  ]},
+ {grp:"Current-sense (piezo classifier)",f:[
+  ["senseProbeDuty","Disc-probe PWM (low)",0,255,1],
+  ["senseDiscPresentMa10x","Disc-present threshold (mA × 10)",0,5000,1],
+  ["senseWaterProbeDuty","Water-probe PWM",0,255,1],
+  ["senseWaterLowMa10x","Water-low threshold (mA × 10)",0,5000,1],
+  ["senseDiscDisconnMidMa10x","Disc-disconnected mid-run threshold (mA × 10)",0,5000,1],
+  ["senseWaterHystMa10x","Water hysteresis (mA × 10)",0,500,1],
+  ["senseWaterCheckIntervalS","Water check interval (s)",5,3600,1],
+  ["senseWaterShutdownS","Water-low countdown (s)",30,7200,10],
+  ["senseUseAsReed","Use current-sense as reed (0/1)",0,1,1],
+  ["senseAutoProbeIntervalS","Auto-probe interval (s, reed-disabled)",1,3600,1],
+ ]},
 ];
 
 // --- helpers ----------------------------------------------------------------
@@ -429,6 +446,22 @@ function applyStatus(d){
   $("bStLOn").classList.toggle("active",sOv===1);
   $("bStLOff").classList.toggle("active",sOv===0);
 
+  // Piezo pill — classifier state + last probe current. WATER_LOW shows the
+  // countdown until WATER_DEPLETED triggers a hard-stop.
+  if(d.piezoState!=null){
+    let label = d.piezoState;
+    if(d.piezoState==="WATER_LOW" && d.waterCountdownS>0){
+      const mm = Math.floor(d.waterCountdownS/60), ss = d.waterCountdownS%60;
+      label = "low water ("+mm+":"+(ss<10?"0":"")+ss+")";
+    } else if(d.piezoState==="WATER_OK"){ label = "ok"; }
+      else if(d.piezoState==="DISC_MISSING"){ label = "no disc"; }
+      else if(d.piezoState==="DISC_DISCONNECTED"){ label = "disc fell off"; }
+      else if(d.piezoState==="WATER_DEPLETED"){ label = "empty — lift to reset"; }
+      else if(d.piezoState==="UNKNOWN"){ label = "—"; }
+    $("pPiezo").textContent = label;
+    $("pPiezoMa").textContent = (d.piezoProbeMa||0).toFixed(1) + " mA";
+  }
+
   // Debug tab raw row
   $("dCur").textContent=d.meanMa.toFixed(1);
   $("dVar").textContent=d.varMa2.toFixed(1);
@@ -497,6 +530,26 @@ $("bForceIdle").addEventListener("click",()=>postJson("/api/cmd/state",{state:"i
 $("bStLAuto").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"auto"}).catch(e=>toast(e.message,"err")));
 $("bStLOn").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"on"}).catch(e=>toast(e.message,"err")));
 $("bStLOff").addEventListener("click",()=>postJson("/api/cmd/statled",{mode:"off"}).catch(e=>toast(e.message,"err")));
+
+// Calibrate water — capture mA at water-probe duty, offer to apply ×0.85 as
+// the new low-water threshold. Best run while mist is actively flowing with
+// known-good water level.
+$("bCalWater").addEventListener("click",async()=>{
+  if(!ensureAdmin()) return;
+  try{
+    const r = await postJson("/api/cmd/calibrate-water");
+    const recorded = r.recordedMa.toFixed(1);
+    const recommended = r.recommendedLowMa.toFixed(1);
+    if(confirm("Recorded "+recorded+" mA. Apply recommended low-water threshold of "+recommended+" mA (~85% of recorded)?")){
+      const v10 = Math.round(r.recommendedLowMa * 10);
+      await postJson("/api/config",{field:"senseWaterLowMa10x",value:v10});
+      toast("Threshold set to "+recommended+" mA","ok");
+      loadConfig();
+    } else {
+      toast("Recorded "+recorded+" mA (not applied)","ok");
+    }
+  }catch(e){ toast("Calibrate failed: "+e.message,"err"); }
+});
 
 // --- Mist pulse depth (UI-friendly wrapper around cfg.mistWaveTroughQ8) ----
 // pulseDepth% 0..100 maps to troughQ8 = round((1-pulse/100)*256). 0% pulse


### PR DESCRIPTION
## Summary
Phase B current-sense classifier: uses the existing INA180A3 to detect disc-presence and water level without adding hardware.

- **Disc-presence detection** at PWM=10 (active in `senseUseAsReed` mode, also runs every 5 s during RUNNING for fast removal-detection).
- **Water-level monitoring** at PWM=64 every 60 s; below threshold starts a 5 min countdown to hard-stop (WATER_DEPLETED). Hysteresis on recovery prevents flapping.
- **DISC_DISCONNECTED** detection (mid-run disc-fall-off) is distinct from low-water — immediate fade-out, no countdown.
- **Calibrate-water button** in the web UI: captures current at probe duty, recommends low-water threshold at 85% of recorded.
- **Status pill** in the web UI showing piezo health + last probe mA + countdown if active.
- All thresholds are NVS-persisted config fields; tunable via `/api/config`.
- `senseUseAsReed` toggle bypasses the reed switch entirely and uses an auto-probe at PWM=10 every 5 s during IDLE for dock detection.

## Codex P2 findings (addressed in b0671c6)
- F1: fast disc-removal check in reed-disabled mode (water probe alone is too slow).
- F2: water/disc probes skip when boost rail is off (user set level=0 in RUNNING).
- F3: calibrate endpoint rejects when mist is not actively running (would persist 0 mA threshold).

## Test plan
- [x] arduino-cli compile passes (96 % flash, 42.9 KB headroom).
- [x] /codex:review findings addressed (b0671c6).
- [x] Internal /review pass — boost-rail guards consistent, cadence reasonable, API rejection path matches conventions.
- [ ] Hardware smoke test on next flash: confirm probe + classifier across dock / lift / low-water / disc-disconnect / calibrate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
