### PR TITLE
Hide disc-removal probe inside the wave trough

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/piezo_sense.ino
@@ -14,6 +14,7 @@ extern bool mistIsInhibited();
 extern bool mistIsRunning();
 extern void mistBoostOnForProbe();
 extern void mistBoostOffForProbe();
+extern uint8_t waveIntensityAtPiezo(uint32_t now);
 
 static PiezoState g_piezoState     = PiezoState::UNKNOWN;
 static float      g_lastProbeMa    = 0.0f;
@@ -108,16 +109,35 @@ void piezoSensePeriodicWaterCheck() {
 // Fast disc-presence check during RUNNING — only relevant when senseUseAsReed
 // is enabled, since reed-removal events are ignored in that mode. Probes at
 // PWM=10 every senseAutoProbeIntervalS; below threshold → DISC_DISCONNECTED.
-// The main loop catches the state change and fades out. Less visible than the
-// water probe (PWM=10 vs 64) and much faster cadence than 60 s water checks.
+//
+// To keep the 5 s cadence but hide the visible mist dip + LED freeze, the
+// probe is "armed" on each interval and then deferred until the wave's
+// natural trough (gauss at piezo ≈ 0) — that's already the dimmest moment,
+// so dropping PWM to 10 for 20 ms there is almost imperceptible. Bounded by
+// a 2 s timeout so the cadence doesn't drift if a trough is slow to arrive.
 void piezoSensePeriodicDiscCheck() {
   static uint32_t lastTickMs = 0;
+  static uint32_t armedAtMs  = 0;   // 0 = not armed
   const uint32_t now = millis();
   if (lastTickMs == 0) { lastTickMs = now; return; }
-  if (now - lastTickMs < uint32_t(cfg.senseAutoProbeIntervalS) * 1000u) return;
-  lastTickMs = now;
-  if (!mistIsRunning()) return;   // mist paused — no meaningful read available
-  const float ma = probeAtDuty(cfg.senseProbeDuty, 30, 30);
+  if (now - lastTickMs >= uint32_t(cfg.senseAutoProbeIntervalS) * 1000u) {
+    lastTickMs = now;
+    armedAtMs = now;                // arm — actual probe waits for trough
+  }
+  if (armedAtMs == 0) return;
+  if (!mistIsRunning()) { armedAtMs = 0; return; }
+
+  // Threshold ≈ bottom 10% of the gauss range. Most of each wave cycle is
+  // below this, so we almost always probe in-trough within the 2 s budget.
+  const uint8_t gauss = waveIntensityAtPiezo(now);
+  if (gauss > 24 && (now - armedAtMs) < 2000u) return;
+  armedAtMs = 0;
+
+  // Shorter probe (20 ms total) than the IDLE-mode auto-probe: the boost
+  // rail is already engaged and steady, so 10 ms is plenty of settle for
+  // a PWM duty change at 108.7 kHz. 10 ms of sampling at the ESP32-C6 ADC
+  // rate is still ~3000 samples — overkill for a stable mean.
+  const float ma = probeAtDuty(cfg.senseProbeDuty, 10, 10);
   const float thresh = float(cfg.senseDiscPresentMa10x) / 10.0f;
   g_lastProbeMa = ma;
   Serial.printf("[SENSE] removal-check: %.1f mA (thresh %.1f)\n", ma, thresh);


### PR DESCRIPTION
## Summary
Fixes the visible every-5 s pause in current-sense reed-replacement mode.

**Root cause.** When `senseUseAsReed=true`, the firmware adds a disc-removal probe every `senseAutoProbeIntervalS` (5 s). Each probe forced PWM to 10 and blocked the loop for ~60 ms — a 3-frame LED freeze plus a sharp mist dip.

**Fix (two layers).**
1. **Trough-sync.** Instead of probing the instant the interval elapses, the probe is *armed* and then deferred until `waveIntensityAtPiezo()` is below the bottom ~10 % of its range. That's already the dimmest moment of the wave, so the brief PWM=10 dip lands when the user expects the mist to be quiet. A 2 s timeout guarantees the cadence never drifts even if a trough is slow to arrive.
2. **Shorter probe.** 60 ms → 20 ms (10 ms settle + 10 ms sample). The boost rail is already engaged + steady; piezo mechanical settling at 108.7 kHz happens in ~1 ms, so 30 ms of settle was 30× the actual need. 10 ms sampling still captures ~3000 ADC reads — plenty for a stable mean.

Net effect: pauses are now almost imperceptible, with no change to the 5 s cadence or threshold logic.

## Test plan
- [x] arduino-cli compile passes (97 %, 37.6 KB headroom; +50 B flash, +8 B RAM for one static)
- [ ] Hardware smoke in current-sense mode: confirm visible pauses are gone while removal still triggers within ~5 s of lifting

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
