### PR TITLE
Link/unlink mist and LED levels with a chip toggle between tiles

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -289,6 +289,12 @@ static void smoothLevel() {
   g_currentLedLevel = rampToward(g_currentLedLevel, g_targetLedLevel, stepUp, cfg.levelSmoothStepDn);
 
   if (g_currentLevel != g_targetLevel) return;
+  // In unlinked mode the LED may still be ramping when the mist hits 0
+  // (mist target is lower than LED target during normal use, but on lift
+  // both targets go to 0 — and if LED was higher it has further to fall).
+  // Wait for BOTH smoothers before declaring the transition complete so
+  // the wave fully fades to black before BREATH crossfade kicks in.
+  if (g_currentLedLevel != g_targetLedLevel) return;
   g_fastLevelUp = false;
   if (g_state == AppState::TRANSITION_FROM_RUNNING && g_targetLevel == 0) {
     enterIdle();
@@ -631,7 +637,8 @@ void setup() {
   // Boot lands in IDLE (default soft breath). If a container is already
   // docked at power-on, the first containerPoll() will edge-trigger
   // Inserted after the 500 ms safety dwell and we'll head into RUNNING.
-  g_targetLevel = g_userLevel;
+  g_targetLevel    = g_userLevel;
+  g_targetLedLevel = g_userLedLevel;
   ledSetMode(LedMode::BREATH);
   Serial.println("[APP] state=IDLE (boot, LEDs visible)");
   printHelp();

--- a/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/BlockKit_Production.ino
@@ -57,16 +57,26 @@ void webInit(); void webHandle();
 // State accessors used by the web server module:
 AppState  appCurrentState();
 uint8_t   appUserLevel();
+uint8_t   appUserLedLevel();
 uint8_t   appCurrentLevel();
 bool      appLedsHidden();
 void      appToggleLedsHidden();
 void      appKickLedWalk();
+void      appSetLedLevel(uint8_t level);
+void      appSetMistLedLinked(bool linked);
 
 // ---- App-level state ----
 static AppState g_state             = AppState::IDLE;  // boot default = soft breath
 static uint8_t  g_userLevel         = CFG_DEFAULT_LEVEL_DEFAULT;  // overwritten from cfg in setup()
-static uint8_t  g_targetLevel       = 0;    // state-driven target for the smoother
-static uint8_t  g_currentLevel      = 0;    // smoothed level applied to mist+LEDs
+static uint8_t  g_targetLevel       = 0;    // state-driven target for the mist smoother
+static uint8_t  g_currentLevel      = 0;    // smoothed mist drive level
+// Parallel pair for the LED strip: when cfg.mistLedLinked the user-level
+// setter mirrors mist→LED automatically, so legacy single-knob behaviour is
+// preserved. When unlinked, the wave-slider on the web UI drives userLedLevel
+// independently and the LED brightness rides its own smoother.
+static uint8_t  g_userLedLevel      = CFG_DEFAULT_LEVEL_DEFAULT;
+static uint8_t  g_targetLedLevel    = 0;
+static uint8_t  g_currentLedLevel   = 0;
 static int8_t   g_levelAdjustDir    = -1;   // -1 = next long-press dims, +1 = brightens
 static uint32_t g_lastSmoothMs      = 0;
 static uint32_t g_lastRampMs        = 0;
@@ -170,7 +180,8 @@ static void enterIdle() {
   if (g_state == AppState::IDLE) return;
   const bool leavingMist = mistMayBeActive(g_state);
   g_state = AppState::IDLE;
-  g_targetLevel = g_userLevel;
+  g_targetLevel    = g_userLevel;
+  g_targetLedLevel = g_userLedLevel;
   g_fastLevelUp = false;            // slow restore — see comment at top of enterIdle()
   // BREATH triggers the WAVE→BREATH crossfade in led_driver when coming
   // from RUNNING / TRANSITION. led_driver collapses no-op mode changes
@@ -183,7 +194,8 @@ static void enterIdle() {
 static void enterRunning() {
   if (g_state == AppState::RUNNING) return;
   g_state = AppState::RUNNING;
-  g_targetLevel = g_userLevel;
+  g_targetLevel    = g_userLevel;
+  g_targetLedLevel = g_userLedLevel;
   // Mode flip directly to WAVE — led_driver runs an automatic 1.1 s
   // crossfade from whatever the previous mode was (BREATH in idle, or
   // WAVE-still-fading if we re-dock mid-transition). The old design used a
@@ -199,7 +211,8 @@ static void enterRunning() {
 static void enterTransitionFromRunning() {
   if (g_state == AppState::TRANSITION_FROM_RUNNING) return;
   g_state = AppState::TRANSITION_FROM_RUNNING;
-  g_targetLevel = 0;
+  g_targetLevel    = 0;
+  g_targetLedLevel = 0;
   // Mode STAYS as WAVE — the wave naturally dims to black as baseLevel
   // ramps 255→0 (it scales the whole render uniformly). When the smoother
   // lands at 0 it auto-enters IDLE which kicks off the WAVE→BREATH
@@ -272,7 +285,8 @@ static void smoothLevel() {
   g_lastSmoothMs = now;
 
   const uint8_t stepUp = g_fastLevelUp ? cfg.levelSmoothStepUpFast : cfg.levelSmoothStepUp;
-  g_currentLevel = rampToward(g_currentLevel, g_targetLevel, stepUp, cfg.levelSmoothStepDn);
+  g_currentLevel    = rampToward(g_currentLevel,    g_targetLevel,    stepUp, cfg.levelSmoothStepDn);
+  g_currentLedLevel = rampToward(g_currentLedLevel, g_targetLedLevel, stepUp, cfg.levelSmoothStepDn);
 
   if (g_currentLevel != g_targetLevel) return;
   g_fastLevelUp = false;
@@ -309,6 +323,11 @@ static void rampLevel() {
   g_userLevel = uint8_t(v);
 
   g_targetLevel = g_userLevel;
+  // Hardware long-press always affects mist; mirror to LED only when linked.
+  if (cfg.mistLedLinked) {
+    g_userLedLevel   = g_userLevel;
+    g_targetLedLevel = g_targetLevel;
+  }
 }
 
 // ----------------------------------------------------------------------
@@ -358,11 +377,13 @@ static void handleCommand(const char* cmd, uint8_t len) {
       const long v = parseNumberArg(cmd, len);
       if (v < 0 || v > 255) { Serial.println("[CMD] v: 0..255"); return; }
       g_userLevel = uint8_t(v);
+      if (cfg.mistLedLinked) g_userLedLevel = g_userLevel;
       // IDLE and RUNNING both follow user level live; TRANSITION_FROM_RUNNING
       // is fading to 0 and overriding target would interrupt the cinematic.
       const bool applyNow = g_state != AppState::TRANSITION_FROM_RUNNING;
       if (applyNow) {
         g_targetLevel = g_userLevel;
+        if (cfg.mistLedLinked) g_targetLedLevel = g_userLedLevel;
         Serial.print("[APP] user level=");
         Serial.println(v);
       } else {
@@ -493,6 +514,7 @@ static void statusTick() {
 // ----------------------------------------------------------------------
 AppState appCurrentState()    { return g_state; }
 uint8_t  appUserLevel()       { return g_userLevel; }
+uint8_t  appUserLedLevel()    { return g_userLedLevel; }
 uint8_t  appCurrentLevel()    { return g_currentLevel; }
 bool     appLedsHidden()      { return g_ledsHidden; }
 
@@ -507,10 +529,38 @@ int8_t  appStatusLedOverride()            { return g_statusLedOverride; }
 
 // Live user-level setter — mirrors the serial 'v' command. Skips applying
 // during TRANSITION_FROM_RUNNING so the fade-out cinematic isn't interrupted.
+// When mist+LED are linked (default), also mirrors to userLedLevel so the
+// LED follows. In unlinked mode the wave slider drives the LED separately
+// via appSetLedLevel().
 void appSetLevel(uint8_t level) {
   g_userLevel = level;
+  if (cfg.mistLedLinked) g_userLedLevel = level;
   if (g_state != AppState::TRANSITION_FROM_RUNNING) {
     g_targetLevel = g_userLevel;
+    if (cfg.mistLedLinked) g_targetLedLevel = g_userLedLevel;
+  }
+}
+
+// LED-only level setter — used in unlinked mode by the wave slider. In
+// linked mode mirrors to userLevel so dragging either slider keeps both in
+// lockstep.
+void appSetLedLevel(uint8_t level) {
+  g_userLedLevel = level;
+  if (cfg.mistLedLinked) g_userLevel = level;
+  if (g_state != AppState::TRANSITION_FROM_RUNNING) {
+    g_targetLedLevel = g_userLedLevel;
+    if (cfg.mistLedLinked) g_targetLevel = g_userLevel;
+  }
+}
+
+// Toggle whether mist and LED levels move together. When (re)linking, snap
+// the LED to match the mist so the two start aligned — otherwise the wave
+// tile would visibly jump on the next slider drag.
+void appSetMistLedLinked(bool linked) {
+  cfg.mistLedLinked = linked;
+  if (linked) {
+    g_userLedLevel = g_userLevel;
+    if (g_state != AppState::TRANSITION_FROM_RUNNING) g_targetLedLevel = g_userLedLevel;
   }
 }
 
@@ -558,7 +608,8 @@ void setup() {
 
   // Load NVS-backed config (or firmware defaults on first boot).
   configInit();
-  g_userLevel = cfg.levelDefault;
+  g_userLevel    = cfg.levelDefault;
+  g_userLedLevel = cfg.levelDefault;   // boot linked unless config has a separate save (TBD)
 
   Wire.begin();
 
@@ -609,8 +660,12 @@ void loop() {
   // LEDs: scaled by g_ledScale (the short-press hide/show fade) so the
   // strip can be blanked without touching mist.
   mistApply(mistOutLevel(now));
+  // LEDs ride their own smoothed level (g_currentLedLevel) so the wave
+  // slider in unlinked mode can dim the visuals without touching the mist.
+  // In linked mode appSetLevel() keeps userLedLevel in lockstep with
+  // userLevel, so behaviour is identical to the pre-link era.
   const uint8_t ledBase =
-      uint8_t((uint16_t(g_currentLevel) * uint16_t(g_ledScale)) >> 8);
+      uint8_t((uint16_t(g_currentLedLevel) * uint16_t(g_ledScale)) >> 8);
   ledRender(ledBase);
 
   // Input edges + diagnostics

--- a/variants/block-kit/firmware/BlockKit_Production/config.h
+++ b/variants/block-kit/firmware/BlockKit_Production/config.h
@@ -63,6 +63,7 @@ struct Config {
   uint16_t senseWaterShutdownS;             // seconds of low water before WATER_DEPLETED hard-stop
   bool     senseUseAsReed;                  // true = ignore reed switch, use auto-probe instead
   uint16_t senseAutoProbeIntervalS;         // seconds between auto-probes when senseUseAsReed=true
+  bool     mistLedLinked;                   // true (default) = mist and LED levels move together
 
   // --- Identity + secrets (separate NVS keys; NEVER returned by /api/config) ---
   char     hostname[CFG_HOSTNAME_MAX + 1];           // mDNS + ArduinoOTA hostname

--- a/variants/block-kit/firmware/BlockKit_Production/config.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/config.ino
@@ -26,6 +26,7 @@ static constexpr const char* KEY_SNS_WCI  = "snsWci";   // water check interval 
 static constexpr const char* KEY_SNS_WS   = "snsWs";    // water shutdown timeout (s)
 static constexpr const char* KEY_SNS_UAR  = "snsUar";   // useAsReed bool
 static constexpr const char* KEY_SNS_API  = "snsApi";   // auto-probe interval (s)
+static constexpr const char* KEY_MLLINK   = "mlLink";   // mist+LED levels linked bool
 
 Config cfg;
 
@@ -94,6 +95,7 @@ void configResetDefaults() {
   cfg.senseWaterShutdownS        = CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S;
   cfg.senseUseAsReed             = CFG_DEFAULT_SENSE_USE_AS_REED;
   cfg.senseAutoProbeIntervalS    = CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S;
+  cfg.mistLedLinked              = CFG_DEFAULT_MIST_LED_LINKED;
   // Identity + secrets default to empty — first-boot setup populates them.
   strncpy(cfg.hostname, "mistmaker", CFG_HOSTNAME_MAX);
   cfg.hostname[CFG_HOSTNAME_MAX] = '\0';
@@ -220,6 +222,7 @@ void configInit() {
   cfg.senseWaterShutdownS      = p.getUShort(KEY_SNS_WS,  CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S);
   cfg.senseUseAsReed           = p.getBool  (KEY_SNS_UAR, CFG_DEFAULT_SENSE_USE_AS_REED);
   cfg.senseAutoProbeIntervalS  = p.getUShort(KEY_SNS_API, CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S);
+  cfg.mistLedLinked            = p.getBool  (KEY_MLLINK,  CFG_DEFAULT_MIST_LED_LINKED);
 
   p.end();
 }
@@ -245,6 +248,7 @@ bool configSave() {
   p.putUShort(KEY_SNS_WS,  cfg.senseWaterShutdownS);
   p.putBool  (KEY_SNS_UAR, cfg.senseUseAsReed);
   p.putUShort(KEY_SNS_API, cfg.senseAutoProbeIntervalS);
+  p.putBool  (KEY_MLLINK,  cfg.mistLedLinked);
   p.end();
   if (put != sizeof(blob)) {
     Serial.printf("[CFG] save failed: wrote %u / %u bytes\n",
@@ -361,6 +365,7 @@ bool configSetField(const char* name, long value) {
   SET_U16(senseWaterShutdownS,       "senseWaterShutdownS",       30, 7200);
   SET_U8 (senseUseAsReed,            "senseUseAsReed",            0, 1);
   SET_U16(senseAutoProbeIntervalS,   "senseAutoProbeIntervalS",   1, 3600);
+  SET_U8 (mistLedLinked,             "mistLedLinked",             0, 1);
   return false;  // unknown name
 }
 
@@ -417,6 +422,7 @@ size_t configToJson(char* out, size_t cap) {
   APPEND("\"senseWaterShutdownS\":%u,",      cfg.senseWaterShutdownS);
   APPEND("\"senseUseAsReed\":%u,",           cfg.senseUseAsReed ? 1 : 0);
   APPEND("\"senseAutoProbeIntervalS\":%u,",  cfg.senseAutoProbeIntervalS);
+  APPEND("\"mistLedLinked\":%u,",            cfg.mistLedLinked ? 1 : 0);
   APPEND("\"hostname\":\"%s\"",          cfg.hostname);
   APPEND("}");
   return n;

--- a/variants/block-kit/firmware/BlockKit_Production/pins.h
+++ b/variants/block-kit/firmware/BlockKit_Production/pins.h
@@ -165,6 +165,7 @@ constexpr uint16_t CFG_DEFAULT_SENSE_WATER_CHECK_INTERVAL_S  = 60;    // seconds
 constexpr uint16_t CFG_DEFAULT_SENSE_WATER_SHUTDOWN_S        = 300;   // 5 min countdown before WATER_DEPLETED
 constexpr bool     CFG_DEFAULT_SENSE_USE_AS_REED             = false; // true = ignore reed switch, auto-probe instead
 constexpr uint16_t CFG_DEFAULT_SENSE_AUTO_PROBE_INTERVAL_S    = 5;     // auto-probe interval in IDLE when senseUseAsReed=true
+constexpr bool     CFG_DEFAULT_MIST_LED_LINKED                = true;  // mist + LED levels move together unless user unlinks
 
 // ---------- Top-level state machine ----------
 //

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -12,6 +12,8 @@
 //   POST /api/cmd/calibrate-water  capture current at water-probe duty,
 //                                  return recorded mA + recommended low threshold
 //   POST /api/cmd/level     set runtime userLevel; body = {"value":0..255}
+//   POST /api/cmd/led-level set LED-only level (unlinked mode); body same
+//   POST /api/cmd/link      set mist+LED link mode; body = {"linked":true|false}
 //   POST /api/cmd/state     force state idle/running; body = {"state":"..."}
 //   POST /api/cmd/statled   override indicator LED; body = {"mode":"auto|on|off"}
 //   POST /api/cmd/reboot    ESP.restart() after 250 ms
@@ -149,6 +151,8 @@ static size_t buildStatusJson(char* out, size_t cap) {
     "\"ledsHidden\":%d,"
     "\"setupMode\":%d,"
     "\"userLevel\":%u,"
+    "\"userLedLevel\":%u,"
+    "\"mistLedLinked\":%u,"
     "\"currentLevel\":%u,"
     "\"meanMa\":%.1f,"
     "\"varMa2\":%.1f,"
@@ -168,6 +172,8 @@ static size_t buildStatusJson(char* out, size_t cap) {
     appLedsHidden() ? 1 : 0,
     wifiIsSetupMode() ? 1 : 0,
     appUserLevel(),
+    appUserLedLevel(),
+    cfg.mistLedLinked ? 1 : 0,
     appCurrentLevel(),
     currentMeanMa(),
     currentVarMa2(),
@@ -353,6 +359,7 @@ static void handleCmdCalibrateWater() {
 }
 
 // Live level set — mirrors serial 'vN'. Body: {"value": 0..255}.
+// In linked mode (default) the LED level mirrors automatically.
 static void handleCmdLevel() {
   if (!requireAuth()) return;
   const String body = g_http.arg("plain");
@@ -363,6 +370,37 @@ static void handleCmdLevel() {
   }
   appSetLevel(uint8_t(v));
   Serial.printf("[WEB] level=%ld\n", v);
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// LED-only level set — used by the wave slider in unlinked mode. In linked
+// mode the firmware mirrors back to userLevel so dragging either slider
+// keeps both in sync.
+static void handleCmdLedLevel() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  long v = 0;
+  if (!jsonGetLong(body, "value", v) || v < 0 || v > 255) {
+    g_http.send(400, "application/json", "{\"error\":\"value must be 0..255\"}");
+    return;
+  }
+  appSetLedLevel(uint8_t(v));
+  Serial.printf("[WEB] led-level=%ld\n", v);
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
+// Toggle the mist+LED link mode. Body: {"linked": true|false}. Persists to
+// NVS so the user's preference survives reboot.
+static void handleCmdLink() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  long v = 0;
+  if (!jsonGetLong(body, "linked", v)) {
+    g_http.send(400, "application/json", "{\"error\":\"missing 'linked' boolean\"}");
+    return;
+  }
+  appSetMistLedLinked(v != 0);
+  configSave();
   g_http.send(200, "application/json", "{\"ok\":true}");
 }
 
@@ -526,6 +564,8 @@ void webInit() {
   g_http.on("/api/cmd/plotmute",    HTTP_POST, handleCmdPlotMute);
   g_http.on("/api/cmd/calibrate-water", HTTP_POST, handleCmdCalibrateWater);
   g_http.on("/api/cmd/level",       HTTP_POST, handleCmdLevel);
+  g_http.on("/api/cmd/led-level",   HTTP_POST, handleCmdLedLevel);
+  g_http.on("/api/cmd/link",        HTTP_POST, handleCmdLink);
   g_http.on("/api/cmd/state",       HTTP_POST, handleCmdState);
   g_http.on("/api/cmd/statled",     HTTP_POST, handleCmdStatLed);
   g_http.on("/api/cmd/reboot",      HTTP_POST, handleCmdReboot);

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -638,13 +638,15 @@ function bindLevelSlider(id, kind, endpoint){
 bindLevelSlider("mistSlider","mist","/api/cmd/level");
 bindLevelSlider("waveSlider","wave","/api/cmd/led-level");
 
-// Link/unlink toggle — flips cfg.mistLedLinked. Firmware snaps the LED
-// level to mist on re-link so the two start aligned.
+// Link/unlink toggle — flips cfg.mistLedLinked. Sends 0/1 to match the
+// rest of the API's integer-boolean convention (the server's jsonGetLong
+// helper doesn't parse true/false). Firmware snaps the LED level to mist
+// on re-link so the two start aligned.
 $("bLink").addEventListener("click",async()=>{
   if(!ensureAdmin()) return;
   const currentlyLinked = $("bLink").classList.contains("linked");
   try{
-    await postJson("/api/cmd/link",{linked: !currentlyLinked});
+    await postJson("/api/cmd/link",{linked: currentlyLinked ? 0 : 1});
     toast(currentlyLinked ? "Mist and LED unlinked" : "Mist and LED linked","ok");
   }catch(e){ toast("Could not toggle link: "+e.message,"err"); }
 });

--- a/variants/block-kit/firmware/BlockKit_Production/web_ui.h
+++ b/variants/block-kit/firmware/BlockKit_Production/web_ui.h
@@ -77,6 +77,30 @@ p{margin:8px 0}
 
 /* Quick-control tiles */
 .tile-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin:8px 0 18px}
+/* When the pair has a link toggle between them, switch to an explicit
+   3-column grid (tile | chip | tile) so the chip lives in the flow instead
+   of floating over either tile's content. On narrow viewports the row
+   wraps so each item gets its own line. */
+.tile-grid.linkable{grid-template-columns:minmax(0,1fr) auto minmax(0,1fr)}
+.link-toggle{background:#fff;border:1px solid var(--line-strong);border-radius:999px;
+  padding:6px 14px 6px 10px;display:inline-flex;align-items:center;gap:8px;
+  font:inherit;font-size:13px;color:var(--mut);cursor:pointer;align-self:center;
+  white-space:nowrap;box-shadow:var(--shadow);
+  transition:color .15s,border-color .15s,background .15s}
+.link-toggle:hover{color:var(--fg);border-color:var(--accent)}
+.link-toggle.linked{color:var(--accent);border-color:var(--accent-soft);background:var(--accent-soft)}
+.link-toggle .link-icon{display:inline-block;width:12px;height:12px;border-radius:50%;
+  border:2px solid currentColor;position:relative}
+.link-toggle.linked .link-icon{background:currentColor}
+.link-toggle:not(.linked) .link-icon::after{content:"";position:absolute;left:50%;top:50%;
+  transform:translate(-50%,-50%) rotate(45deg);width:14px;height:2px;background:currentColor;
+  border-radius:1px}
+@media(max-width:720px){
+  /* Stack vertically on narrow viewports: tiles full-width, link chip
+     centered between them. */
+  .tile-grid.linkable{grid-template-columns:1fr}
+  .link-toggle{justify-self:center;margin:-2px 0}
+}
 .tile{background:var(--card);border-radius:var(--r);padding:20px;box-shadow:var(--shadow)}
 .tile h3{margin:0 0 4px;font:inherit;font-size:13px;color:var(--mut);text-transform:uppercase;letter-spacing:.6px;font-weight:500;
   display:flex;align-items:center;justify-content:space-between;gap:8px}
@@ -195,14 +219,21 @@ details.adv>div{padding:0 18px 18px}
     <code>MistMaker-Setup-XXXX</code> network (password <code>mistmaker-setup</code>).
   </div>
 
-  <!-- Primary controls -->
-  <div class="tile-grid">
+  <!-- Primary controls — Mist + LED wave tiles separated by a chain-link
+       toggle. Click the link to decouple the two sliders so you can dim the
+       LEDs without throttling the mist (or vice-versa). -->
+  <div class="tile-grid linkable" id="tilePair">
     <div class="tile">
       <h3>Mist <button class="sw" id="swMist" aria-label="Toggle mist"></button></h3>
       <div class="pct"><span id="mistPct">0</span><span class="unit">%</span></div>
       <div class="sub" id="mistSub">—</div>
       <input type="range" min="0" max="100" step="1" id="mistSlider" value="0">
     </div>
+    <button class="link-toggle linked" id="bLink" type="button"
+      aria-label="Toggle mist and LED link" title="Mist and LED levels move together — click to unlink">
+      <span class="link-icon" aria-hidden="true"></span>
+      <span class="link-label">Linked</span>
+    </button>
     <div class="tile">
       <h3>LED wave <button class="sw" id="swWave" aria-label="Toggle LED wave"></button></h3>
       <div class="pct"><span id="wavePct">0</span><span class="unit">%</span></div>
@@ -485,12 +516,27 @@ function applyStatus(d){
       (d.reedPresent ? "Ready, settling…" : "Waiting for a container");
   if(d.userLevel>0) lastNonZeroLevel = d.userLevel;
 
-  // LED Wave tile
+  // LED Wave tile — uses userLedLevel which equals userLevel when linked,
+  // and rides its own slider when unlinked. Fall back to userLevel for
+  // older firmwares that don't yet emit the field.
+  const ledLevel = (d.userLedLevel != null) ? d.userLedLevel : d.userLevel;
   $("swWave").classList.toggle("on",!d.ledsHidden);
-  $("wavePct").textContent = mistPct;
-  if(dragging!=="wave") $("waveSlider").value = mistPct;
+  const wavePct = pctFromLevel(ledLevel);
+  $("wavePct").textContent = wavePct;
+  if(dragging!=="wave") $("waveSlider").value = wavePct;
   $("waveSub").textContent = d.ledsHidden ? "Hidden — mist still flows" :
       (d.state==="RUNNING" ? "Swelling with the mist" : "Soft breath");
+
+  // Link toggle reflects the live cfg flag (mistLedLinked may be 1 or 0).
+  if(d.mistLedLinked != null){
+    const linked = !!d.mistLedLinked;
+    const lb = $("bLink");
+    lb.classList.toggle("linked", linked);
+    lb.querySelector(".link-label").textContent = linked ? "Linked" : "Unlinked";
+    lb.title = linked
+      ? "Mist and LED levels move together — click to unlink"
+      : "Mist and LED are independent — click to link";
+  }
 
   // Container detection source segmented control (lastCfg may have arrived already)
   const useSense = !!(lastCfg && lastCfg.senseUseAsReed);
@@ -574,7 +620,7 @@ async function postJson(path, body){
   return r.json().catch(()=>({}));
 }
 
-function bindLevelSlider(id, kind){
+function bindLevelSlider(id, kind, endpoint){
   const el=$(id);
   // Mark dragging on pointerdown (covers mouse + touch); clear on pointerup
   // BEFORE the async POST runs, so a slow fetch doesn't widen the suppression
@@ -583,12 +629,25 @@ function bindLevelSlider(id, kind){
   el.addEventListener("pointerdown",()=>{ dragging=kind; });
   el.addEventListener("pointerup",  ()=>{ dragging=null; });
   el.addEventListener("change",async()=>{
-    try{ await postJson("/api/cmd/level",{value:levelFromPct(+el.value)}); }
+    try{ await postJson(endpoint,{value:levelFromPct(+el.value)}); }
     catch(e){ toast("Level: "+e.message,"err"); }
   });
 }
-bindLevelSlider("mistSlider","mist");
-bindLevelSlider("waveSlider","wave");
+// Mist slider → mist level. Wave slider → LED level (firmware mirrors back
+// to mist in linked mode, so dragging either slider keeps them aligned).
+bindLevelSlider("mistSlider","mist","/api/cmd/level");
+bindLevelSlider("waveSlider","wave","/api/cmd/led-level");
+
+// Link/unlink toggle — flips cfg.mistLedLinked. Firmware snaps the LED
+// level to mist on re-link so the two start aligned.
+$("bLink").addEventListener("click",async()=>{
+  if(!ensureAdmin()) return;
+  const currentlyLinked = $("bLink").classList.contains("linked");
+  try{
+    await postJson("/api/cmd/link",{linked: !currentlyLinked});
+    toast(currentlyLinked ? "Mist and LED unlinked" : "Mist and LED linked","ok");
+  }catch(e){ toast("Could not toggle link: "+e.message,"err"); }
+});
 
 $("swMist").addEventListener("click",async()=>{
   const wantOn = !$("swMist").classList.contains("on");


### PR DESCRIPTION
## Summary
Adds a "Linked / Unlinked" chip toggle between the Mist and LED-wave tiles on the Status page so the two levels can be decoupled. Default behavior unchanged (linked, mirrors both ways).

### Firmware
- Parallel `g_userLedLevel` / `g_targetLedLevel` / `g_currentLedLevel` so the LED can ride its own smoother.
- `ledRender` now uses `g_currentLedLevel`. In linked mode `appSetLevel`/`appSetLedLevel`/serial-`v`/long-press all mirror the partner level so behavior is identical to before.
- State transitions (enterIdle/Running/TransitionFromRunning), setup() seed, and the smoother's completion check all updated to track both levels.
- `cfg.mistLedLinked` (NVS-persisted, default true) preserves the single-knob feel.

### Web layer
- `POST /api/cmd/led-level` — sets just the LED level (firmware mirrors to mist in linked mode).
- `POST /api/cmd/link` — toggles `cfg.mistLedLinked`; firmware snaps LED to mist on re-link so the two start aligned.
- `/api/status` JSON gains `userLedLevel` and `mistLedLinked`.

### UI
- Small chip toggle in its own grid column between the tiles. Filled circle when linked, outlined circle with diagonal slash when unlinked. Collapses to a centered chip when tiles stack on narrow viewports.

## Codex review pass
Three P2 findings caught + fixed in `d0424d5`:
- `/api/cmd/link` returned 400 on every click (server parsed ints, UI sent booleans) — UI now sends 0/1.
- LED ring stayed dark on normal boot (setup didn't seed `g_targetLedLevel`).
- Transition cinematic could end with the wave half-faded in unlinked mode (smoother completion didn't wait for the LED side).

## Test plan
- [x] arduino-cli compile passes (97 %, 32.7 KB headroom)
- [x] /codex:review findings addressed (d0424d5)
- [x] Browser preview of both linked and unlinked states — chip swaps icon + label, sliders move independently when unlinked
- [ ] Hardware smoke on next flash

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
