### PR TITLE
Add POST /api/cmd/wave-period for sensor-driven breath rate

### DIFF
--- a/variants/block-kit/firmware/BlockKit_Production/API.md
+++ b/variants/block-kit/firmware/BlockKit_Production/API.md
@@ -58,6 +58,7 @@ int rc = http.POST("{\"value\":180}");
 | GET    | `/api/log`                    | none        | Last ~6 KB of serial log as plain text                          |
 | GET    | `/api/events`                 | none        | Server-Sent Events stream of `/api/status` (§5)                 |
 | POST   | `/api/cmd/level`              | admin       | Set user level 0..255. Body: `{"value":N}` (mist + LED intensity) |
+| POST   | `/api/cmd/wave-period`        | admin       | Live wave-period set (RAM only, no NVS). Body: `{"ms":N}` (500..60000) or `{"bpm":N}` (1..120). |
 | POST   | `/api/cmd/state`              | admin       | Force state. Body: `{"state":"idle"\|"running"}`                |
 | POST   | `/api/cmd/leds`               | admin       | Toggle LED strip hide/show (mist unaffected). No body.          |
 | POST   | `/api/cmd/walk`               | admin       | Run a one-shot LED chase animation. No body.                    |
@@ -87,6 +88,7 @@ JSON object emitted by `GET /api/status` and each SSE `data:` frame. Stable wire
   "ledsHidden": 0,            // int: 1 if the LED strip has been faded out by short-press
   "setupMode": 0,             // int: 1 if device is in WiFi captive-portal setup mode
   "userLevel": 255,           // u8: 0..255 user-set intensity (mist + LED)
+  "wavePeriodMs": 7500,       // u16: current wave-animation period in ms (live, see §7)
   "currentLevel": 255,        // u8: smoothed level actually being applied
   "meanMa": 12.3,             // float: rolling 256-sample mean current (mA)
   "varMa2": 0.5,              // float: rolling variance, mA^2
@@ -197,6 +199,21 @@ For tightly-coupled experiments you can even rewrite thresholds on the fly:
 // Make the diffuser more sensitive to early water-low warnings:
 postJson("/api/config", "{\"field\":\"senseWaterLowMa10x\",\"value\":1200}");
 ```
+
+### Driving the wave from a live breathing sensor
+
+A separate device on the LAN — say an mmWave radar breathing-rate sensor — can drive the mist maker's LED wave + mist modulation at the user's actual respiratory rate. Use `/api/cmd/wave-period`, **not** `/api/config`, for live streaming: the dedicated endpoint updates RAM only, so a sensor pushing once per second won't burn through the NVS sector that backs the saved config blob.
+
+```cpp
+// each fresh breath estimate from the sensor
+const int bpm = mmwave.bpm();          // e.g. 6..30
+postJson("/api/cmd/wave-period",
+         String("{\"bpm\":") + bpm + "}");
+```
+
+The next `/api/status` (or SSE frame) carries the updated `wavePeriodMs`, so the companion can confirm acceptance without polling `/api/config`. Reboot reverts to the NVS-persisted default (factory: 7500 ms); to change the *baseline* rate, POST once to `/api/config` instead.
+
+Avoid changing the period more often than once per breath cycle — the wave's phase is computed as `millis() % wavePeriodMs`, so a large abrupt jump can snap the visible swell to a new position. Small breath-to-breath drift (e.g. 6800 → 7200 ms) is sub-pixel and invisible.
 
 ## 8. Notes and gotchas
 

--- a/variants/block-kit/firmware/BlockKit_Production/API.md
+++ b/variants/block-kit/firmware/BlockKit_Production/API.md
@@ -213,7 +213,7 @@ postJson("/api/cmd/wave-period",
 
 The next `/api/status` (or SSE frame) carries the updated `wavePeriodMs`, so the companion can confirm acceptance without polling `/api/config`. Reboot reverts to the NVS-persisted default (factory: 7500 ms); to change the *baseline* rate, POST once to `/api/config` instead.
 
-Avoid changing the period more often than once per breath cycle — the wave's phase is computed as `millis() % wavePeriodMs`, so a large abrupt jump can snap the visible swell to a new position. Small breath-to-breath drift (e.g. 6800 → 7200 ms) is sub-pixel and invisible.
+Be aware that changing the period mid-cycle can cause a visible **phase jump** in the swell. The wave's phase is computed as `millis() % wavePeriodMs`, so the new position after the change depends on the absolute uptime value and may land anywhere within the new cycle — even small period changes can hop the swell to a different LED. If smooth motion matters more than rapid response, debounce sensor updates to once every few breath cycles, or accept the discontinuity as part of the look.
 
 ## 8. Notes and gotchas
 

--- a/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/led_driver.ino
@@ -8,6 +8,13 @@
 #include "pins.h"
 #include "config.h"
 
+// Live wave-period override pushed by streaming companions (e.g. an mmWave
+// breathing sensor) via POST /api/cmd/wave-period. 0 means "no override —
+// use the NVS-persisted cfg.wavePeriodMs". Kept OUT of the Config struct
+// on purpose so the next configSave() can't accidentally bake a transient
+// sensor reading into NVS. Cleared on reboot.
+uint16_t g_liveWavePeriodMs = 0;
+
 // LUT size — 64-entry lookup tables (one inhale/exhale cycle for breath,
 // 0..4σ for gauss). Size is a power of 2 so we can mask instead of mod.
 constexpr uint8_t LUT_SIZE = 64;
@@ -194,7 +201,8 @@ static void renderBreathRaw(uint32_t now, uint8_t out[LED_COUNT]) {
 static inline int32_t waveCenterYQ8(uint32_t now) {
   const int32_t spanQ8 = int32_t(LED_COUNT) * 256
                         + int32_t(WAVE_TRAVEL_PAD_Q8) * 2;
-  const uint16_t period = cfg.wavePeriodMs ? cfg.wavePeriodMs : 1;
+  const uint16_t baseline = cfg.wavePeriodMs ? cfg.wavePeriodMs : 1;
+  const uint16_t period   = g_liveWavePeriodMs ? g_liveWavePeriodMs : baseline;
   const uint32_t t = uint32_t(now) % period;
   return int32_t(LED_COUNT) * 256 + int32_t(WAVE_TRAVEL_PAD_Q8)
        - int32_t((uint64_t(spanQ8) * t) / period);

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -55,6 +55,7 @@ extern void     wifiForgetAndReboot();
 extern bool     wifiIsSetupMode();
 extern size_t   logSnapshot(char*, size_t);
 extern Config   cfg;   // defined in config.ino
+extern uint16_t g_liveWavePeriodMs;   // defined in led_driver.ino; 0 = use cfg.wavePeriodMs
 
 static WebServer  g_http(80);
 
@@ -176,7 +177,7 @@ static size_t buildStatusJson(char* out, size_t cap) {
     appUserLevel(),
     appUserLedLevel(),
     cfg.mistLedLinked ? 1 : 0,
-    cfg.wavePeriodMs,
+    g_liveWavePeriodMs ? g_liveWavePeriodMs : cfg.wavePeriodMs,
     appCurrentLevel(),
     currentMeanMa(),
     currentVarMa2(),
@@ -413,8 +414,8 @@ static void handleCmdWavePeriod() {
     g_http.send(400, "application/json", "{\"error\":\"ms must be 500..60000\"}");
     return;
   }
-  cfg.wavePeriodMs = uint16_t(ms);
-  Serial.printf("[WEB] wavePeriodMs=%ld (live)\n", ms);
+  g_liveWavePeriodMs = uint16_t(ms);
+  Serial.printf("[WEB] wavePeriodMs=%ld (live override)\n", ms);
   g_http.send(200, "application/json", "{\"ok\":true}");
 }
 

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -13,6 +13,7 @@
 //                                  return recorded mA + recommended low threshold
 //   POST /api/cmd/level     set runtime userLevel; body = {"value":0..255}
 //   POST /api/cmd/led-level set LED-only level (unlinked mode); body same
+//   POST /api/cmd/wave-period live wave-period set; body = {"ms":N} or {"bpm":N}
 //   POST /api/cmd/link      set mist+LED link mode; body = {"linked":true|false}
 //   POST /api/cmd/state     force state idle/running; body = {"state":"..."}
 //   POST /api/cmd/statled   override indicator LED; body = {"mode":"auto|on|off"}
@@ -389,6 +390,32 @@ static void handleCmdLedLevel() {
   g_http.send(200, "application/json", "{\"ok\":true}");
 }
 
+// Live wave-period set — for a streaming companion (e.g. an mmWave breathing
+// sensor) that wants the LED wave + mist modulation to breathe at the user's
+// actual respiratory rate. Body: {"ms": 500..60000} OR {"bpm": 1..120}.
+// RAM only — does NOT call configSave(), so high-frequency updates won't
+// chew through NVS flash cycles. Reboot reverts to the persisted default
+// (set once via POST /api/config if you want a different baseline).
+static void handleCmdWavePeriod() {
+  if (!requireAuth()) return;
+  const String body = g_http.arg("plain");
+  long ms = 0, bpm = 0;
+  if (!jsonGetLong(body, "ms", ms)) {
+    if (!jsonGetLong(body, "bpm", bpm) || bpm <= 0) {
+      g_http.send(400, "application/json", "{\"error\":\"need 'ms' or 'bpm'\"}");
+      return;
+    }
+    ms = 60000L / bpm;
+  }
+  if (ms < 500 || ms > 60000) {
+    g_http.send(400, "application/json", "{\"error\":\"ms must be 500..60000\"}");
+    return;
+  }
+  cfg.wavePeriodMs = uint16_t(ms);
+  Serial.printf("[WEB] wavePeriodMs=%ld (live)\n", ms);
+  g_http.send(200, "application/json", "{\"ok\":true}");
+}
+
 // Toggle the mist+LED link mode. Body: {"linked": true|false}. Persists to
 // NVS so the user's preference survives reboot.
 static void handleCmdLink() {
@@ -565,6 +592,7 @@ void webInit() {
   g_http.on("/api/cmd/calibrate-water", HTTP_POST, handleCmdCalibrateWater);
   g_http.on("/api/cmd/level",       HTTP_POST, handleCmdLevel);
   g_http.on("/api/cmd/led-level",   HTTP_POST, handleCmdLedLevel);
+  g_http.on("/api/cmd/wave-period", HTTP_POST, handleCmdWavePeriod);
   g_http.on("/api/cmd/link",        HTTP_POST, handleCmdLink);
   g_http.on("/api/cmd/state",       HTTP_POST, handleCmdState);
   g_http.on("/api/cmd/statled",     HTTP_POST, handleCmdStatLed);

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -403,15 +403,19 @@ static void handleCmdWavePeriod() {
   if (!requireAuth()) return;
   const String body = g_http.arg("plain");
   long ms = 0, bpm = 0;
-  if (!jsonGetLong(body, "ms", ms)) {
-    if (!jsonGetLong(body, "bpm", bpm) || bpm <= 0) {
-      g_http.send(400, "application/json", "{\"error\":\"need 'ms' or 'bpm'\"}");
+  if (jsonGetLong(body, "ms", ms)) {
+    if (ms < 500 || ms > 60000) {
+      g_http.send(400, "application/json", "{\"error\":\"ms must be 500..60000\"}");
+      return;
+    }
+  } else if (jsonGetLong(body, "bpm", bpm)) {
+    if (bpm < 1 || bpm > 120) {
+      g_http.send(400, "application/json", "{\"error\":\"bpm must be 1..120\"}");
       return;
     }
     ms = 60000L / bpm;
-  }
-  if (ms < 500 || ms > 60000) {
-    g_http.send(400, "application/json", "{\"error\":\"ms must be 500..60000\"}");
+  } else {
+    g_http.send(400, "application/json", "{\"error\":\"need 'ms' or 'bpm'\"}");
     return;
   }
   g_liveWavePeriodMs = uint16_t(ms);

--- a/variants/block-kit/firmware/BlockKit_Production/web_server.ino
+++ b/variants/block-kit/firmware/BlockKit_Production/web_server.ino
@@ -154,6 +154,7 @@ static size_t buildStatusJson(char* out, size_t cap) {
     "\"userLevel\":%u,"
     "\"userLedLevel\":%u,"
     "\"mistLedLinked\":%u,"
+    "\"wavePeriodMs\":%u,"
     "\"currentLevel\":%u,"
     "\"meanMa\":%.1f,"
     "\"varMa2\":%.1f,"
@@ -175,6 +176,7 @@ static size_t buildStatusJson(char* out, size_t cap) {
     appUserLevel(),
     appUserLedLevel(),
     cfg.mistLedLinked ? 1 : 0,
+    cfg.wavePeriodMs,
     appCurrentLevel(),
     currentMeanMa(),
     currentVarMa2(),


### PR DESCRIPTION
## Summary

- Adds `POST /api/cmd/wave-period` so a streaming companion device (e.g. an mmWave breathing sensor) can push live updates of the LED wave + mist modulation period. Accepts either `{"ms":N}` (500..60000) or `{"bpm":N}` (1..120) — the sensor can post whichever unit it already produces.
- Uses a non-persisted `g_liveWavePeriodMs` override so high-frequency sensor traffic never touches NVS (a 1 Hz sensor would otherwise burn through the ~100k-cycle config sector in a day).
- Surfaces `wavePeriodMs` in `/api/status` (and therefore the SSE stream) so the companion can confirm its write took effect on the very next frame.
- Documents the endpoint, status field, and a worked mmWave-sensor example in `API.md` §3, §4, §7 — including an honest note on the `millis() % period` phase discontinuity.

## Review trail

- `codex:rescue` external review caught one IMPORTANT issue and one MINOR issue — both addressed in atomic follow-up commits before pushing:
  - **IMPORTANT** — original draft wrote `cfg.wavePeriodMs` directly, which would have been swept into NVS by any unrelated `configSave()` call. Fixed by introducing `g_liveWavePeriodMs` (commit `87fde13`).
  - **MINOR** — original API.md claim "sub-pixel and invisible" drift was too rosy. Reworded honestly (commit `d0f8514`).
- Built-in `/review` pass surfaced one UX nit on error messages — addressed in commit `827d63c` (path-specific errors so a `{"bpm":121}` client sees `"bpm must be 1..120"` not `"ms must be 500..60000"`).

## Flash budget

| Stage | Bytes | % of 1,310,720 | Δ from baseline |
| --- | ---: | ---: | ---: |
| Baseline (main) | 1,278,086 | 97% | — |
| + handler + route | 1,278,666 | 97% | +580 |
| + status field | 1,278,696 | 97% | +30 |
| + NVS-leak fix | 1,278,744 | 97% | +658 |
| + UX error msgs | 1,278,798 | 97% | +712 |

Final headroom: **31,922 bytes** (2.4%) under the 1.31 MB partition cap. RAM unchanged at 19%. Zero new warnings.

## Test plan

- [ ] Flash to XIAO ESP32-C6 hardware
- [ ] `curl http://mistmaker.local/api/status | jq .wavePeriodMs` → returns persisted value (7500 by default)
- [ ] `curl -u admin:<pw> -X POST .../api/cmd/wave-period -d '{"bpm":20}'` → `{"ok":true}`; next status shows `wavePeriodMs: 3000`; LED wave visibly speeds up
- [ ] Same with `{"ms":9000}` → LED wave visibly slows
- [ ] `{"bpm":121}` → 400 with `"bpm must be 1..120"` (not the ms-range message)
- [ ] `{"ms":100}` → 400 with `"ms must be 500..60000"`
- [ ] Empty body → 400 with `"need 'ms' or 'bpm'"`
- [ ] Unauthenticated POST → 401 (after admin password is set)
- [ ] Push a live override, then toggle link mode via web UI; reboot; confirm `wavePeriodMs` returns to the persisted baseline (proves the NVS-leak fix)
- [ ] Subscribe to `/api/events`; confirm `wavePeriodMs` updates within one SSE frame of each POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)