### PR TITLE
Docs: science update (rescued) + docs.byproductlab.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This [Open Source Hardware Certified](https://certification.oshwa.org/us002742.html) ultrasonic mist maker project transforms recycled containers and a custom PCB into a small-form-factor mist device. It is a fully documented, low-cost circuit with accessible explanations of misting mechanics, design challenges, and power needs.
 
-[Full Documentation on Notion](https://dav1dyang.notion.site/programmable-mist-maker)
+[Full Documentation Site](https://dav1dyang.github.io/Programmable-Mist-Maker/)
 
 [Full Documentation on Hackster.io](https://www.hackster.io/dav1dyang/waste-into-wonder-making-programmable-mist-makers-fe3ae7)
 
@@ -56,7 +56,7 @@ Mist generation involves:
 * **PWM Switching**: An ESP32-C6 sends a 108.7 kHz PWM signal to a MOSFET.
 * **Power Supply**: TPS61023 provides stable 5V from LiPo or USB input.
 
-More details: [Notion Documentation](https://dav1dyang.notion.site/programmable-mist-maker)
+More details: [Documentation Site](https://dav1dyang.github.io/Programmable-Mist-Maker/)
 
 ## Key Components
 ![PCB Board Components](assets/2025-05-22_V1-4_Board_Only.jpg)
@@ -173,7 +173,7 @@ Please make sure to use distilled or clean tap water in the reservoir, fully cle
 * GreatScott! Ultrasonic Mist Explanation (YouTube)
 * BigCliveDotCom Mist Maker Teardown (YouTube)
 
-Full reference list in: [Notion Documentation](https://dav1dyang.notion.site/programmable-mist-maker)
+Full reference list in: [Documentation Site](https://dav1dyang.github.io/Programmable-Mist-Maker/)
 
 ## Documentation Notes
 

--- a/docs/boards/battery-kit.md
+++ b/docs/boards/battery-kit.md
@@ -105,5 +105,6 @@ MistMaker mist(MistMakerBatteryKitV03());
     the water container. For workshops in venues that restrict lithium batteries, run
     this board from USB-C only — it works fine without a cell.
 
-- Always connect USB **before** battery when developing, or the serial port may not
-  enumerate (see [programming notes](../how-it-works.md#programming-notes)).
+- Develop with the battery connected or not — the TPS2116 power mux always prefers
+  USB when it's present, so serial enumeration and uploads just work (this fixes the
+  power-sequence quirk of the [legacy V1.4 board](legacy-v1-4.md#known-quirks-fixes)).

--- a/docs/boards/legacy-v1-4.md
+++ b/docs/boards/legacy-v1-4.md
@@ -32,6 +32,25 @@ for new builds, start with the [Extension Kit](extension-kit.md) or
 V1.4 pioneered the recycled-container approach — duck and UFO enclosure STLs live in
 [`legacy/v1-4/EnclosureDesignMaterials/`](https://github.com/Dav1dyang/Programmable-Mist-Maker/tree/main/legacy/v1-4/EnclosureDesignMaterials).
 
+## Known quirks & fixes
+
+These issues are specific to V1.4 and were designed away in the V0.x boards (power
+mux, dedicated boost rail, gate driver, no OTA-on-boot). If you're reproducing this
+board, the original workarounds:
+
+| Issue | Fix |
+|---|---|
+| Mist fails on battery | Bypass the XIAO's 3.3 V regulator with an external boost converter — the onboard regulator handles USB fine but not battery |
+| Uploading code fails while misting | Add a pull-down to the MOSFET gate; disable the boost converter during uploads |
+| Startup delay | Disable OTA; add a delay between enabling the TPS61023 and activating the mist PWM |
+
+!!! note "Power sequence matters (V1.4 only)"
+    When developing on this board, always connect **USB first, then battery** — if
+    battery power is applied before USB, the serial port may not enumerate in the
+    Arduino IDE. Once serial is up, battery can be connected freely. Standalone,
+    either power source works alone. (The V0.x Battery Kit's TPS2116 power mux
+    eliminates this entirely.)
+
 ## Firmware
 
 Legacy example sketches:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,53 +1,91 @@
 # How It Works
 
 Every board in this project is the same idea with different power plumbing: an ESP32
-shakes a piezo disc at its resonant frequency until water turns into mist.
+shakes a piezo disc at its resonant frequency until water turns into mist. The
+interesting part is *how* a 5 V USB rail ends up swinging tens of volts across a
+ceramic disc — and why one strange little inductor makes it all work.
 
 ![How a cheap humidifier works](https://raw.githubusercontent.com/Dav1dyang/Programmable-Mist-Maker/main/assets/Exsiting_Cheap_Humidifier_Design.gif)
 
-## The mist engine
+## The disc: atomization at 108.7 kHz
 
-1. **Ultrasonic vibration** — a piezo disc oscillating at **108.7 kHz** tears water
-   into droplets small enough to float.
-2. **PWM switching** — the XIAO ESP32-C6 outputs a 108.7 kHz PWM signal (up to 50%
-   duty) into a gate driver + MOSFET.
-3. **Voltage boosting** — the MOSFET switches a 3-legged tapped inductor
-   (auto-transformer) in a loop with the disc; LC resonance boosts the 5 V rail to the
-   **~30–40 Vpp** the disc actually needs.
-4. **Current sensing** — an INA180A3 amplifier reads the voltage across a 30 mΩ shunt
-   (3.0 V per amp). A missing disc, a dry disc, and a disc in water each draw
-   distinctly different current — so one ADC pin gives you disc detection *and* a
-   water sensor for free.
+The mist disc isn't just a vibrating plate — it's a **micro-perforated atomizer**. The
+center of the disc has microscopic holes; a cotton wick feeds water to the back side,
+and as the piezo ceramic flexes at **108.7 kHz** (its mechanical resonance), each
+oscillation pumps water through those holes, ejecting droplets fine enough to float as
+a cool mist. No heat involved — the "steam" is room-temperature water.
+
+This is why disc orientation matters (white ring faces up — mist exits there), why a
+dirty or dry disc stops misting, and why running a disc dry can overheat it. Disc
+behavior, droplet formation, and hole geometry are beautifully illustrated in the
+[MDPI ultrasonic atomization study](https://www.mdpi.com/2076-3417/11/18/8350) that
+informed this design.
+
+## The resonant drive: 5 V in, ~30–40 Vpp out
+
+A piezo disc is electrically a capacitor, and it wants far more voltage than a USB
+port offers. Commercial humidifiers solve this with a clever resonant circuit, which
+these boards adapt:
 
 ```
-5V ──► gate driver ──► MOSFET ──► 3-leg inductor ──► piezo disc (108.7 kHz)
-        ▲ PWM from ESP32              (LC resonance: 5 V → ~30–40 Vpp)
+5V ──► gate driver ──► MOSFET ──► 3-leg tapped inductor ──► piezo disc (108.7 kHz)
+        ▲ PWM from ESP32              (autotransformer + LC resonance)
 5V current ──► 30 mΩ shunt ──► INA180A3 ──► ADC pin
 ```
+
+1. The ESP32 outputs a **108.7 kHz PWM** (up to 50% duty) into a gate driver + MOSFET.
+2. The MOSFET rapidly switches the tapped inductor in a loop with the disc's own
+   capacitance, forming an **LC tank** that rings at the drive frequency.
+3. The inductor is *tapped* — three legs, roughly a **28 µH : 800 µH** winding ratio —
+   so it doubles as an **autotransformer**, stepping the ringing voltage up to the
+   ~30–40 Vpp the disc needs (V1.4-era boards measured as high as ~80 Vpp).
+4. Mist strength tracks how well the drive frequency matches the disc + inductor
+   resonance — which is exactly why `setLevel()` (PWM duty) modulates mist like a
+   dimmer.
+5. As a bonus, the current flowing through a 30 mΩ shunt (read by an INA180A3,
+   3.0 V/A) differs measurably between *no disc*, *dry disc*, and *disc in water* —
+   one ADC pin gives disc detection and a water sensor for free.
+
+Stability details matter at these frequencies: the boards add RC snubbers, TVS
+protection, and careful gate drive (the V0.x boards upgraded from a bare GPIO-driven
+AO3400A to a dedicated UCC27511 gate driver for clean edges).
+
+## The part you can't buy at DigiKey
+
+The 3-legged tapped inductor is the soul of this circuit — and the hardest part to
+source in the West. It doesn't meaningfully exist on DigiKey, Mouser, or Amazon, but
+it's abundant and cheap on Taobao and AliExpress (search **“三腳電感”** — "three-leg
+inductor"). It's a workhorse of Shenzhen-ecosystem designs: the same component that
+makes commercial humidifiers compact is used to make **piezo buzzers in fire and smoke
+alarms painfully loud** — same trick, voltage step-up by autotransformer + resonance
+([good StackExchange teardown of exactly this part](https://electronics.stackexchange.com/questions/539843/how-does-the-component-alarm-boost-three-pin-inductor-make-a-piezo-buzzer-loud)).
+
+!!! tip "Can't get the tapped inductor?"
+    Misting works without it. A standard **680 µH inductor** in series with the disc
+    forms an LC resonator with the piezo's built-in capacitance; drive it at
+    ~113 kHz, add a 100 nF DC-blocking capacitor, and you get effective (if less
+    efficient) mist. We verified this alternative experimentally — it trades the
+    hard-to-source part for a slightly larger, simpler circuit.
 
 ## Design evolution
 
 ![PCB design progress](https://raw.githubusercontent.com/Dav1dyang/Programmable-Mist-Maker/main/assets/PCB_Board_Design_Progress.gif)
 
-The project started by reverse-engineering cheap commercial humidifier circuits, then
-rebuilding them as documented, hackable boards. The full design story is on
+The project started by reverse-engineering cheap commercial humidifier circuits
+(see [BigClive's teardown](https://www.youtube.com/watch?v=_TXlhOsPJyo) and
+[GreatScott's explainer](https://www.youtube.com/watch?v=OOZi3QnnDCo)), then rebuilding
+them as documented, hackable boards. The full design story is on
 [Hackster](https://www.hackster.io/dav1dyang/waste-into-wonder-making-programmable-mist-makers-fe3ae7).
 
-## Known issues & fixes
-
-| Issue | Fix |
-|---|---|
-| Mist fails on battery | Bypass the XIAO's 3.3 V regulator with an external boost converter |
-| Uploading code fails | Add a pull-down to the MOSFET gate; disable the boost rail during upload |
-| Startup delay | Disable OTA; add a delay before activating mist |
-
-## Programming notes
-
-!!! note "Power sequence matters"
-    When developing, always connect **USB first, then battery**. If battery power is
-    applied before USB, the serial port may not enumerate in the Arduino IDE. Once
-    serial is up, battery can be connected freely. Standalone (no computer), either
-    power source works alone.
+**What we learned the hard way — and fixed in the current boards.** The V1.4 workshop
+board had three classic quirks: mist failing on battery (the XIAO's onboard 3.3 V
+regulator couldn't feed the boost stage), uploads failing while misting, and an
+OTA-related startup delay. The V0.x boards design these problems away — the
+[Battery Kit](boards/battery-kit.md)'s **TPS2116 power mux** cleanly separates USB and
+battery paths (so programming just works, battery connected or not), the piezo rail
+has its own dedicated boost converter, and the current firmware dropped the
+OTA-on-boot pattern entirely. If you're reproducing the original board, the old fixes
+are preserved on the [Legacy V1.4 page](boards/legacy-v1-4.md#known-quirks-fixes).
 
 ## Use and care
 
@@ -57,9 +95,28 @@ rebuilding them as documented, hackable boards. The full design story is on
     distilled or clean tap water, clean the container regularly, and let cotton
     sticks dry fully between uses. Keep electronics dry where they should be dry.
 
-## References
+- Never run the disc without water for long (it can overheat), and never drive the
+  circuit without a disc attached (the MOSFET can overheat).
+- Mist strength varies with water depth, disc cleanliness, and supply voltage.
 
-- TPS61023 datasheet — Texas Instruments
-- MCP73831 datasheet — Microchip
-- GreatScott! ultrasonic mist explanation (YouTube)
-- BigCliveDotCom mist maker teardown (YouTube)
+## Research & references
+
+The reading list that shaped this design — also linked throughout the
+[original research notes](https://dav1dyang.notion.site/programmable-mist-maker):
+
+**Science & circuit theory**
+
+- [Ultrasonic atomization study (MDPI Applied Sciences)](https://www.mdpi.com/2076-3417/11/18/8350) — disc microstructure and droplet formation
+- [Tapped "alarm boost" inductor explained (Electronics StackExchange)](https://electronics.stackexchange.com/questions/539843/how-does-the-component-alarm-boost-three-pin-inductor-make-a-piezo-buzzer-loud)
+- [Mist maker circuit walkthrough (EDN)](https://www.edn.com/mist-maker/)
+
+**Teardowns & tutorials**
+
+- [GreatScott! — How ultrasonic humidifiers work](https://www.youtube.com/watch?v=OOZi3QnnDCo)
+- [BigCliveDotCom — commercial mist maker teardown](https://www.youtube.com/watch?v=_TXlhOsPJyo)
+- [Nick Electronics — how a humidifier works](https://www.youtube.com/watch?v=bngLvPxtoLA)
+
+**Datasheets**
+
+- [TPS61023 boost converter (TI)](https://www.ti.com/lit/ds/symlink/tps61023.pdf)
+- [AO3400A MOSFET](https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/2587/UMW%20AO3400A.pdf) (legacy V1.4 switch; V0.x uses DMT10H009LCG + UCC27511)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Programmable Mist Maker
 site_description: >-
   Open-source, programmable ultrasonic mist maker kits — hardware, firmware,
   and the MistMaker Arduino library. OSHWA certified US002742.
-site_url: https://dav1dyang.github.io/Programmable-Mist-Maker/
+site_url: https://docs.byproductlab.com/
 repo_url: https://github.com/Dav1dyang/Programmable-Mist-Maker
 repo_name: Programmable-Mist-Maker
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Two things:

1. **Rescues a stranded commit**: the How It Works science rewrite (MDPI atomization, tapped-inductor autotransformer + Taobao sourcing story, 680µH alternative, V1.4 troubleshooting retired to the Legacy page, README Notion→Pages links) was pushed to `feat/docs-site` ~30 min *after* PR #20 had already been merged, so it never reached main — cherry-picked here.
2. **Custom domain**: `site_url` → `https://docs.byproductlab.com/` to match the Pages custom-domain setting (canonical URLs + sitemap).

`mkdocs build --strict` clean. Merging deploys both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)