### PR TITLE
Remove stale USB-before-battery warning from Battery Kit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,11 @@ More details: [Documentation Site](https://dav1dyang.github.io/Programmable-Mist
 
 ## Programming Notes
 
-### Important Note on Power Sequence and Serial Connectivity
+### Power sequence (legacy V1.4 only)
 
-When connecting the board for development or testing:
+On the **legacy V1.4 board**, always connect USB before applying battery power — if battery comes first, the serial port won't enumerate in the Arduino IDE. Standalone (no computer), either power source works alone.
 
-* Always connect the USB cable first before applying battery power
-* If battery power is connected before USB, the serial port will not be detected in the Arduino IDE
-* The proper sequence is: connect USB → establish serial connection → apply battery power (if needed)
-* Once the USB connection is established, battery power can be applied without disrupting the serial connection
-* When operating in standalone mode without a computer, either power source can be used independently
+The current kits don't have this quirk: the Battery Kit's TPS2116 power mux always prefers USB when present, so uploads work with or without a battery connected.
 
 ## Code & Firmware
 

--- a/variants/battery-kit/README.md
+++ b/variants/battery-kit/README.md
@@ -86,5 +86,5 @@ MistMaker mist(MistMakerBatteryKitV03());
 > [!WARNING]
 > Li-Po safety: only use protected 1S cells, never charge unattended, and keep the cell away from the water container. For workshops in venues that restrict lithium batteries, run this board from USB-C only — it works fine without a cell.
 
-- Always connect USB **before** battery when developing, or the serial port may not enumerate (see root README programming notes).
+- Develop with the battery connected or not — the TPS2116 power mux always prefers USB when present, so serial enumeration and uploads just work (this fixes the legacy V1.4 power-sequence quirk).
 - Safety, cleaning, and known-issues notes live in the [root README](../../README.md).


### PR DESCRIPTION
Per David: the TPS2116 power mux fixed this, so the warning only applies to legacy V1.4. Battery Kit README now states the positive (develop with battery connected or not); the root README's power-sequence section is scoped to V1.4 explicitly so the two files agree with the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)