### PR TITLE
Correct piezo drive voltage to measured ~80 Vpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ schematics** live on the [documentation site](https://docs.byproductlab.com/).
 
 An ESP32 drives a piezo disc at its **108.7 kHz** resonance through a MOSFET and a
 3-legged tapped inductor — an autotransformer + LC tank that steps 5 V up to the
-~30–40 Vpp the disc needs, while a current-sense amp lets the firmware detect the
+~80 Vpp the disc needs, while a current-sense amp lets the firmware detect the
 disc and the water level on one ADC pin. The full story — atomization science, why
 that strange inductor is everywhere in Shenzhen and nowhere at DigiKey, and a
 verified alternative circuit — is at

--- a/docs/boards/battery-kit.md
+++ b/docs/boards/battery-kit.md
@@ -60,7 +60,7 @@ VBAT ─► ½ divider ─► D1 (analog)
 | AP7361C-3.3 | 3V3 LDO |
 | TPS61023 | 3V→5.5V boost for the piezo rail |
 | UCC27511A + DMT10H009LCG | Gate driver + MOSFET, 108.7 kHz switching |
-| 3-legged tapped inductor (CD75) | LC voltage boost to ~30–40 Vpp |
+| 3-legged tapped inductor (CD75) | LC voltage boost to ~80 Vpp |
 | INA180A3 + 30 mΩ shunt | Analog current sense (3.0 V/A) |
 | TS-1088 tactile switch, white LED | User button + status |
 | Qwiic / JST-SH 4-pin | I2C expansion |

--- a/docs/boards/extension-kit.md
+++ b/docs/boards/extension-kit.md
@@ -26,12 +26,12 @@ Explore the actual KiCad schematic right here — scroll to zoom, drag to pan:
 ```
 XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─► 3-leg inductor ─► piezo disc
                 │         ▲ D0: 108.7 kHz PWM                     (LC resonance boosts
-                └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~30–40 Vpp)
+                └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~80 Vpp)
 ```
 
 - The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at up to 50% duty.
 - The MOSFET switches the tapped-inductor + piezo loop; LC resonance boosts the 5 V
-  rail to the ~30–40 Vpp the disc needs.
+  rail to the ~80 Vpp the disc needs (measured on the V1.4 circuit; same topology here).
 - The **INA180A3** (100 V/V) reads the voltage across a 30 mΩ shunt — 3.0 V per amp
   into D2. A dry disc draws visibly less than a wet one, which is how disc-presence
   and water-level detection work.
@@ -52,7 +52,7 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
 |---|---|
 | UCC27511A gate driver | Clean, fast MOSFET gate edges at 108.7 kHz |
 | DMT10H009LCG MOSFET | Switches the resonant loop |
-| 3-legged tapped inductor (CD75) | LC voltage boost to ~30–40 Vpp |
+| 3-legged tapped inductor (CD75) | LC voltage boost to ~80 Vpp |
 | INA180A3 + 30 mΩ shunt | Analog current sense (3.0 V/A) |
 | PH-2.0 connector | Piezo disc |
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -21,7 +21,7 @@ behavior, droplet formation, and hole geometry are beautifully illustrated in th
 [MDPI ultrasonic atomization study](https://www.mdpi.com/2076-3417/11/18/8350) that
 informed this design.
 
-## The resonant drive: 5 V in, ~30–40 Vpp out
+## The resonant drive: 5 V in, ~80 Vpp out
 
 A piezo disc is electrically a capacitor, and it wants far more voltage than a USB
 port offers. Commercial humidifiers solve this with a clever resonant circuit, which
@@ -38,7 +38,7 @@ these boards adapt:
    capacitance, forming an **LC tank** that rings at the drive frequency.
 3. The inductor is *tapped* — three legs, roughly a **28 µH : 800 µH** winding ratio —
    so it doubles as an **autotransformer**, stepping the ringing voltage up to the
-   ~30–40 Vpp the disc needs (V1.4-era boards measured as high as ~80 Vpp).
+   ~80 Vpp the disc needs (measured on the V1.4 circuit — the V0.x boards use the same drive topology).
 4. Mist strength tracks how well the drive frequency matches the disc + inductor
    resonance — which is exactly why `setLevel()` (PWM duty) modulates mist like a
    dimmer.

--- a/variants/battery-kit/README.md
+++ b/variants/battery-kit/README.md
@@ -51,7 +51,7 @@ VBAT ─► ½ divider ─► D1 (analog)
 | AP7361C-3.3 | 3V3 LDO |
 | TPS61023 | 3V→5.5V boost for the piezo rail |
 | UCC27511A + DMT10H009LCG | Gate driver + MOSFET, 108.7 kHz switching |
-| 3-legged tapped inductor (CD75) | LC voltage boost to ~30–40 Vpp |
+| 3-legged tapped inductor (CD75) | LC voltage boost to ~80 Vpp |
 | INA180A3 + 30 mΩ shunt | Analog current sense (3.0 V/A) |
 | TS-1088 tactile switch, white LED | User button + status |
 | Qwiic / JST-SH 4-pin | I2C expansion |

--- a/variants/xiao-extension-kit/README.md
+++ b/variants/xiao-extension-kit/README.md
@@ -17,11 +17,11 @@ Great for: desks, breadboard experiments, classrooms, and anyone's first mist bu
 ```
 XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─► 3-leg inductor ─► piezo disc
                 │         ▲ D0: 108.7 kHz PWM                     (LC resonance boosts
-                └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~30–40 Vpp)
+                └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~80 Vpp)
 ```
 
 - The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at up to 50% duty.
-- The MOSFET switches the tapped-inductor + piezo loop; LC resonance boosts the 5 V rail to the ~30–40 Vpp the disc needs.
+- The MOSFET switches the tapped-inductor + piezo loop; LC resonance boosts the 5 V rail to the ~80 Vpp the disc needs (measured on the V1.4 circuit; same topology here).
 - The **INA180A3** (100 V/V) reads the voltage across a 30 mΩ shunt — 3.0 V per amp into D2. A dry disc draws visibly less than a wet one, which is how disc-presence and water-level detection work.
 
 ## Pin map
@@ -38,7 +38,7 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
 |---|---|
 | UCC27511A gate driver | Clean, fast MOSFET gate edges at 108.7 kHz |
 | DMT10H009LCG MOSFET | Switches the resonant loop |
-| 3-legged tapped inductor (CD75) | LC voltage boost to ~30–40 Vpp |
+| 3-legged tapped inductor (CD75) | LC voltage boost to ~80 Vpp |
 | INA180A3 + 30 mΩ shunt | Analog current sense (3.0 V/A) |
 | PH-2.0 connector | Piezo disc |
 


### PR DESCRIPTION
David remembered the measured Vpp was higher than the docs claimed. Investigation: no Claude Code transcript or Drive note contains a Vpp measurement; the only bench-confirmed figure is the original research notes' **~80 Vpp from 5 V input** (V1.4 circuit, 'confirmed experimentally'). The ~30–40 Vpp in the V0.x READMEs had no traceable source — so the docs were leading with the unsourced number. All 11 occurrences across the docs site, variant READMEs, and root README now state ~80 Vpp, attributed to the V1.4 measurement (same drive topology on V0.x). If a fresh scope measurement on V0.x lands, it's a one-line update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)