### PR TITLE
Battery Kit V0.4 bring-up: ST (USB/cell) sense on D8 + mux-handoff test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,18 @@
 *.swp
 *.tmp
 *.bak
+*.bak-*
 *.log
 .DS_Store
 .vscode/
 *.code-workspace
 __MACOSX/
+
+# KiCad per-user state (view settings, selection filters — no design data)
+*.kicad_prl
+
+# Claude Code worktrees (parallel checkouts — never commit)
+.claude/worktrees/
 
 # Arduino cache and temp folders
 sketchbook/

--- a/docs/boards/battery-kit.md
+++ b/docs/boards/battery-kit.md
@@ -1,9 +1,10 @@
-# Battery Kit — V0.3
+# Battery Kit — V0.4
 
 The portable, single-PCB "grab and go" Mist Maker: Li-Po battery + USB-C charging,
-full power path, piezo drive, current sensing, a button, a status LED — and (new in
-V0.3) **battery voltage monitoring** so the firmware can warn you when the pack is low
-and power down gracefully instead of browning out mid-mist.
+full power path, piezo drive, current sensing, a button, a status LED — and
+**trustworthy battery monitoring**: since V0.4 the board tells the firmware whether
+it is actually running from USB or from the cell, so low-battery logic can never
+false-trigger while you're plugged in.
 
 **Great for:** installations, performances, kits, and anywhere without a USB cable.
 
@@ -16,70 +17,97 @@ and power down gracefully instead of browning out mid-mist.
 <script type="module" src="../../assets/vendor/kicanvas.js"></script>
 <kicanvas-embed src="../../assets/hardware/MistMaker-Battery-Kit-V0-3.kicad_sch" controls="basic"></kicanvas-embed>
 
+*The embed shows V0.3; V0.4 adds the mux-status (ST → D8) divider and a gentler
+charge current — everything else is identical.*
 [KiCad project & production files on GitHub →](https://github.com/Dav1dyang/Programmable-Mist-Maker/tree/main/variants/battery-kit/hardware)
 
 ## How it works
 
 ```
-USB-C ─► LP4060 charger ─► Li-Po ─┐
-                                  ├─► TPS2116 power mux ─► AP7361C 3V3 LDO ─► XIAO
-USB-C 5V ─────────────────────────┘
-                                  └─► TPS61023 boost (EN = D3) ─► 5V5 rail
-5V5 ─► UCC27511 ─► DMT10H009 MOSFET ─► 3-leg inductor ─► piezo disc
-        ▲ D0: 108.7 kHz PWM
-5V5 current ─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)
-VBAT ─► ½ divider ─► D1 (analog)
+USB-C 5V ──────────────┬────────────► TPS2116 power mux ──► PSW_VOUT
+Li-Po ─► LP4060 charger┘                   │        │
+                                           │        ├─► TPS61023 boost (EN = D3) ─► ~5V rail
+                        ST (status) ───────┘        └─► AP7361C 3V3 LDO ─► XIAO 3V3
+                         │                               ▲ (auto-disabled on USB)
+                         ├─► ÷ divider ─► D8  "am I on USB or the cell?"
+                         └─► Q1 ─► LDO EN
+5V ─► 30 mΩ shunt ─► UCC27511 ─► DMT10H009 MOSFET ─► 3-leg inductor ─► piezo disc
+      │                ▲ D0: 108.7 kHz PWM
+      └─► INA180A3 ─► D2 (analog current sense)
+VBAT ─► ½ divider ─► D1 (analog fuel gauge)
 ```
 
-- **Power path:** the TPS2116 mux picks USB when present, battery otherwise; the
-  LP4060 charges the Li-Po from USB-C.
-- **Piezo rail:** the TPS61023 boost (enabled by D3) makes a stable 5.5 V from either
-  source. Turn it off when idle — it's the single biggest standby drain.
-- **Sensing:** INA180A3 + 30 mΩ shunt → analog D2 for disc/water detection; battery
-  divider → D1 for the fuel gauge.
+- **Power path:** the TPS2116 mux picks USB when present (threshold 4.0 V),
+  battery otherwise; the LP4060 charges the Li-Po from USB-C at a thermally
+  gentle **~200 mA** (green LED = charging).
+- **The ST trick (V0.4):** the mux's status pin does double duty — divided down
+  to **D8** it tells firmware which source is live (HIGH = USB, LOW = cell), and
+  through Q1 it **disables the board's 3V3 LDO whenever USB is present**, so the
+  XIAO's own regulator and the board LDO never fight.
+- **Piezo rail:** the TPS61023 boost (enabled by D3) makes a stable ~5 V from
+  either source. Turn it off when idle — it's the single biggest standby drain.
+- **Sensing:** INA180A3 + 30 mΩ shunt → analog D2 for disc/water detection;
+  battery divider → D1 for the fuel gauge.
 
 ## Pin map
 
 | XIAO pin | Net | Function |
 |---|---|---|
 | D0 | `MIST_PWM_3V3` | 108.7 kHz PWM to gate driver |
-| D1 | `D1_BATT_VOLTAGE` | Battery voltage via ½ divider (V0.3+) |
+| D1 | `D1_BATT_VOLTAGE` | Battery voltage via ½ divider |
 | D2 | `D2_CS` | INA180A3 current-sense output |
-| D3 | `D3_TPS_EN` | TPS61023 boost enable (HIGH = 5V5 on) |
+| D3 | `D3_TPS_EN` | TPS61023 boost enable (HIGH = piezo rail on) |
 | D4 / D5 | `D4_SDA` / `D5_SCL` | I2C + Qwiic connector |
 | D6 | `D6_BUTTON` | Button, active HIGH (10k pull-down on PCB) |
 | D7 | `D7_LED` | Status LED |
-| D8–D10 | — | Spare breakout |
+| D8 | `D8_ST` | **Power-mux status (V0.4+):** HIGH = on USB, LOW = on the cell. Read as plain `INPUT` — the on-board divider sets the level |
+| D9–D10 | — | Spare breakout |
 
 ## Key components
 
 | Part | Role |
 |---|---|
-| LP4060B5F | Single-cell Li-Po USB-C charging |
-| TPS2116DRLR | USB/battery power mux |
-| AP7361C-3.3 | 3V3 LDO |
-| TPS61023 | 3V→5.5V boost for the piezo rail |
+| LP4060B5F | Single-cell Li-Po USB-C charging (~200 mA) |
+| TPS2116DRLR | USB/battery power mux + source status (ST → D8) |
+| AP7361C-3.3 | 3V3 LDO (battery operation; auto-off on USB) |
+| TPS61023 | Boost for the ~5 V piezo rail |
 | UCC27511A + DMT10H009LCG | Gate driver + MOSFET, 108.7 kHz switching |
 | 3-legged tapped inductor (CD75) | LC voltage boost to ~80 Vpp |
 | INA180A3 + 30 mΩ shunt | Analog current sense (3.0 V/A) |
 | TS-1088 tactile switch, white LED | User button + status |
 | Qwiic / JST-SH 4-pin | I2C expansion |
 
-## Battery monitoring & graceful shutdown (V0.3)
+## Battery monitoring that can't cry wolf (V0.4)
 
-D1 reads the pack through an equal-resistor divider (ratio 2.0). Guidance, measured
-under load:
+On USB the battery node tracks the *charger*, not the state of charge — V0.3
+firmware reading it blindly caused false low-battery shutdowns. V0.4 fixes this in
+hardware: D8 says which source is live, and the
+[MistMaker library](../library.md) (v2.0+) gates itself on it —
+`batteryState()` returns `CHARGING` on USB and only ever `LOW`/`CRITICAL` when the
+cell is really the source.
 
-| Voltage | Meaning | Firmware should |
+| Voltage (on the cell, under load) | Meaning | Firmware should |
 |---|---|---|
 | 4.2 V | Full | — |
 | ~3.7 V | Nominal | — |
 | < 3.45 V | Low | Warn (LED blink / UI banner) |
 | < 3.20 V | Critical | Mist off → boost off → deep sleep |
 
-The [MistMaker library](../library.md) (v1.1+) wraps this: `batteryState()`,
-`batteryPercent()`, `shutdown()`. The `WiFiPhoneControl` and `HomeAssistant_MQTT`
-examples implement the full graceful power-off.
+The `WiFiPhoneControl` and `HomeAssistant_MQTT` examples implement the full
+graceful power-off (two consecutive critical readings, radio off, deep sleep).
+
+## Power budget & mist ceiling (measured)
+
+From the 2026-07 bench characterization ([full story on the library page](../library.md)):
+
+- **Default drive (50% duty):** ~0.23 A on the 5 V rail, ~0.3 A from the cell —
+  runs cool, sustainable on any supply. This is the library default.
+- **Peak mist (~70% duty, `DUTY_TURBO`):** ~0.83 A on the rail — wall-adapter
+  territory (≥ 2 A recommended); a fully-charged cell can just reach it.
+- The mux switches sources **break-before-make (~1.3 ms)** — a graceful handoff
+  at normal loads (bench-verified: unplug mid-mist, no reset), but at extreme
+  drive (> ~75% duty) a collapsing supply can't be caught. Practical takeaway:
+  the board's supply architecture comfortably covers everything up to peak mist.
 
 ## Build your own
 
@@ -90,12 +118,13 @@ examples implement the full graceful power-off.
 3. Snap in a XIAO ESP32-C6, connect a 1S Li-Po (500 mAh+ recommended).
 4. Flash
    [`BatteryKit_BringUp`](https://github.com/Dav1dyang/Programmable-Mist-Maker/tree/main/variants/battery-kit/firmware/BatteryKit_BringUp)
-   and walk its serial checklist (`h` for help). Check `b` (battery volts) with USB
-   unplugged.
-5. Install the MistMaker library and try the examples — select the board with:
+   and walk its serial checklist (`h` for help) — including the `u` power-source
+   test and the USB unplug/replug **handoff test** (the sketch counts source
+   switches and reports the reset reason, so you get proof the handoff worked).
+5. Install the MistMaker library (v2.0+) and try the examples — select the board with:
 
 ```cpp
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // V0.3 board? MistMakerBatteryKitV03() + disableBattery()
 ```
 
 ## Notes
@@ -108,3 +137,6 @@ MistMaker mist(MistMakerBatteryKitV03());
 - Develop with the battery connected or not — the TPS2116 power mux always prefers
   USB when it's present, so serial enumeration and uploads just work (this fixes the
   power-sequence quirk of the [legacy V1.4 board](legacy-v1-4.md#known-quirks-fixes)).
+- The ~5 V piezo rail is live from power-on (pull-up on the boost enable) until
+  firmware drives D3 — expected on a scope, and harmless: the gate driver holds the
+  piezo off.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -33,7 +33,7 @@ these boards adapt:
 5V current ──► 30 mΩ shunt ──► INA180A3 ──► ADC pin
 ```
 
-1. The ESP32 outputs a **108.7 kHz PWM** (up to 50% duty) into a gate driver + MOSFET.
+1. The ESP32 outputs a **108.7 kHz PWM** (50% duty by default) into a gate driver + MOSFET.
 2. The MOSFET rapidly switches the tapped inductor in a loop with the disc's own
    capacitance, forming an **LC tank** that rings at the drive frequency.
 3. The inductor is *tapped* — three legs, roughly a **28 µH : 800 µH** winding ratio —
@@ -42,6 +42,15 @@ these boards adapt:
 4. Mist strength tracks how well the drive frequency matches the disc + inductor
    resonance — which is exactly why `setLevel()` (PWM duty) modulates mist like a
    dimmer.
+
+    !!! info "Why 50% duty, and where the real maximum is (measured 2026-07)"
+        Longer on-time stores more energy in the inductor, but the resonant
+        "ring-back" needs about half of each 9.2 µs cycle to swing — so past 50%
+        duty the ring gets clipped and efficiency collapses. A full 0→90% duty
+        sweep on V0.4 hardware found mist output actually **peaks near 70% duty**
+        at ~4× the input power of the 50% point, then declines and turns unstable.
+        The library defaults to the efficient 50% cap and exposes the measured
+        peak as `DUTY_TURBO` — see the [library page](library.md).
 5. As a bonus, the current flowing through a 30 mΩ shunt (read by an INA180A3,
    3.0 V/A) differs measurably between *no disc*, *dry disc*, and *disc in water* —
    one ADC pin gives disc detection and a water sensor for free.

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,13 +1,16 @@
 # MistMaker Library
 
 **[MistMaker](https://github.com/owochel/MistMaker)** is the Arduino library for every
-board in this project — PWM mist control, current sensing, and battery monitoring
-behind one friendly API. Treat mist like an LED.
+board in this project — PWM mist control, current sensing, battery monitoring, and
+power-source awareness behind one friendly API. Treat mist like an LED.
 
 ## Install
 
-Arduino IDE → **Library Manager** → search "MistMaker" (v1.1+), or clone
+Arduino IDE → **Library Manager** → search "MistMaker" (v2.0+), or clone
 [owochel/MistMaker](https://github.com/owochel/MistMaker) into your libraries folder.
+
+Every tuning value the library assumes lives in one documented place:
+`namespace MistMakerDefaults` at the top of `MistMaker.h`.
 
 ## Quick start
 
@@ -15,7 +18,8 @@ Arduino IDE → **Library Manager** → search "MistMaker" (v1.1+), or clone
 #include <MistMaker.h>
 
 // One line per board — pick yours:
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also call mist.disableBattery()
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -57,13 +61,28 @@ mist.setSenseThresholds(10.0, 110.0, 70.0);  // or hard-code (mA)
 mist.setCurrentSenseFactor(3.0);        // different shunt/amp? gain × shunt
 ```
 
+## USB or battery? (Battery Kit V0.4)
+
+The V0.4 board routes the power mux's status pin to D8, so firmware always knows
+the real power source:
+
+```cpp
+if (mist.onBattery()) { /* battery reading is a true state-of-charge */ }
+if (mist.usbPresent()) { /* cell is charging; its voltage tracks the charger */ }
+```
+
+Battery monitoring **gates itself** on this: on USB, `batteryState()` returns
+`MIST_BATT_CHARGING` and never `LOW`/`CRITICAL` — the hardware fix for V0.3's
+false low-battery shutdowns. (Without an ST pin, `usbPresent()` is always true —
+fail-safe: a board that can't sense its source will never blind-shut-down.)
+
 ## Battery monitoring (Battery Kit)
 
 ```cpp
-float v   = mist.readBatteryVolts();   // via on-board divider
+float v   = mist.readBatteryVolts();   // calibrated, via on-board divider
 uint8_t p = mist.batteryPercent();     // rough LiPo gauge for UIs
 
-if (mist.batteryCritical()) {          // hysteresis built in
+if (mist.batteryCritical()) {          // hysteresis built in; never fires on USB (V0.4)
   mist.shutdown();                     // mist off + boost rail off
   esp_deep_sleep_start();              // sleep instead of brown-out
 }
@@ -71,6 +90,19 @@ if (mist.batteryCritical()) {          // hysteresis built in
 
 Defaults: divider ratio 2.0, low = 3.45 V, critical = 3.20 V. Override with
 `setBatteryDivider()` / `setBatteryThresholds()`.
+
+## How hard can it drive? (measured)
+
+The duty cap was bench-characterized on real V0.4 hardware (2026-07 sweep, 0→90% duty):
+
+| Cap | What you get |
+|---|---|
+| **default (50% duty)** | ~90% of practical mist at ~¼ of peak power; cool components; battery-sustainable. |
+| `mist.setMaxDuty(MistMakerDefaults::DUTY_TURBO)` (**~70%**) | The measured **true mist maximum** — ~4× the input power; wall adapter (≥ 2 A) territory. |
+| above ~75% | Mist *declines* and turns unstable while current climbs — the library hard-limits at 90% of full scale. |
+
+Your sketch's `setLevel(0..255)` scale is unaffected by the cap — 255 always means
+"my current maximum."
 
 ## Examples
 
@@ -83,6 +115,7 @@ Defaults: divider ratio 2.0, low = 3.45 V, critical = 3.20 V. Override with
 | `WaterDetect` | Disc + water detection, auto-calibration, auto-recovery |
 | `WiFiPhoneControl` | Phone control via WiFi AP + web UI, graceful low-battery shutdown |
 | `HomeAssistant_MQTT` | Native Home Assistant device via MQTT Discovery |
+| `PhoneSensors` | Phone mic / light / motion / face / **music** drive the mist over the internet ([relay + web app included](https://github.com/owochel/MistMaker/tree/main/extras/phone-app)) |
 
 ## Home Assistant without code
 

--- a/variants/battery-kit/README.md
+++ b/variants/battery-kit/README.md
@@ -1,6 +1,8 @@
-# Battery Kit — V0.3
+# Battery Kit — V0.4
 
-The portable, single-PCB "grab and go" Mist Maker: Li-Po battery + USB-C charging, full power path, piezo drive, current sensing, a button, a status LED — and (new in V0.3) **battery voltage monitoring** so the firmware can warn you when the pack is low and power down gracefully instead of browning out mid-mist.
+The portable, single-PCB "grab and go" Mist Maker: Li-Po battery + USB-C charging, full power path, piezo drive, current sensing, a button, a status LED — and **trustworthy battery monitoring**: V0.4 routes the power mux's status pin to the XIAO (D8), so firmware knows whether it is running from USB or the cell and low-battery logic can never false-trigger while plugged in.
+
+> The KiCad/production files in this folder are **V0.3**; V0.4 adds the ST→D8 divider (R21/R22), drops the charge current to ~200 mA (R6 = 5.1 kΩ), and is otherwise identical on D0–D7. V0.4 design files live in the project drive and are pending import here.
 
 Great for: installations, performances, kits, and anywhere without a USB cable.
 
@@ -40,7 +42,8 @@ VBAT ─► ½ divider ─► D1 (analog)
 | D4 / D5 | `D4_SDA` / `D5_SCL` | I2C + Qwiic connector |
 | D6 | `D6_BUTTON` | Button, active HIGH (10k pull-down on PCB) |
 | D7 | `D7_LED` | Status LED |
-| D8–D10 | — | Spare breakout |
+| D8 | `D8_ST` | **Power-mux status (V0.4+):** HIGH = on USB, LOW = on the cell — plain `INPUT`, no internal pull |
+| D9–D10 | — | Spare breakout |
 
 ## Key components ([full BOM](hardware/))
 
@@ -56,9 +59,9 @@ VBAT ─► ½ divider ─► D1 (analog)
 | TS-1088 tactile switch, white LED | User button + status |
 | Qwiic / JST-SH 4-pin | I2C expansion |
 
-## Battery monitoring & graceful shutdown (V0.3)
+## Battery monitoring & graceful shutdown
 
-D1 reads the pack through an equal-resistor divider (ratio 2.0). Guidance, measured under load:
+D1 reads the pack through an equal-resistor divider (ratio 2.0). On USB the node tracks the *charger*, not state-of-charge — which is why V0.4 added the D8 source sense, and why on a V0.3 board you should call `disableBattery()`. Guidance, measured under load (valid on the cell):
 
 | Voltage | Meaning | Firmware should |
 |---|---|---|
@@ -67,7 +70,7 @@ D1 reads the pack through an equal-resistor divider (ratio 2.0). Guidance, measu
 | < 3.45 V | Low | Warn (LED blink / UI banner) |
 | < 3.20 V | Critical | Mist off → boost off → deep sleep |
 
-The [MistMaker library](https://github.com/owochel/MistMaker) (v1.1+) wraps this: `batteryState()`, `batteryPercent()`, `shutdown()`. The `WiFiPhoneControl` and `HomeAssistant_MQTT` examples implement the full graceful power-off.
+The [MistMaker library](https://github.com/owochel/MistMaker) (v2.0+) wraps this and gates it on the D8 source sense — `batteryState()` returns `CHARGING` on USB and only ever `LOW`/`CRITICAL` on the cell: `batteryState()`, `batteryPercent()`, `usbPresent()`, `shutdown()`. The `WiFiPhoneControl` and `HomeAssistant_MQTT` examples implement the full graceful power-off.
 
 ## Build your own
 

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
@@ -6,15 +6,21 @@
 //   1. "does the button work?"            -> press it: mist + LED toggle
 //   2. "does the boost rail come up?"     -> `t`, scope the 5 V rail or watch mist
 //   3. "is the INA180 reading anything?"  -> `c` prints one current reading
-//   4. "which source is the mux on?"      -> `u`: plug/unplug USB, watch it flip
+//   4. "is the mux ST sense alive?"       -> `u` reads USB present (D8 HIGH);
+//                                            meter TP3 for the cell/LOW case
 //   5. "does the battery divider read?"   -> `b` prints volts + validity
 //   6. "dry vs wet separation?"           -> `s` streams CSV for the Plotter
 //   7. "does dimming work?"               -> `0`..`9` sets duty
 //
 // The TPS2116 power mux (V0.4) runs the board off USB whenever it's plugged
-// in, so Vbatt only reflects true state-of-charge when on the cell. D8 (the
-// mux ST pin) tells us which: HIGH = USB, LOW = battery — so `b` and the
-// status line only classify OK/LOW/CRITICAL when actually on the cell.
+// in, so Vbatt reflects true state-of-charge only on the cell. D8 (mux ST)
+// tells us which: HIGH = USB, LOW = battery. `b`/`[STAT]` always print the
+// voltage + OK/LOW/CRITICAL tag and add "[USB - charging]" on USB (where the
+// number tracks the charger, not SoC).
+//
+// NOTE: on this board USB is the only serial link, so over the console D8
+// almost always reads HIGH (USB). To confirm the LOW/cell state, meter TP3
+// (or D8) with the cell in and USB out — you can't watch it flip over serial.
 //
 // Expected (XIAO C6, INA180A3, 30 mOhm shunt, duty 64):
 //   no disc ~0 mA · disc dry ~70-100 mA · disc in water ~130-200 mA
@@ -123,14 +129,12 @@ void loop() {
     else if (ch == 'c') { Serial.printf("[CUR] %.1f mA\n", readMa()); }
     else if (ch == 'b') {
       const float v = readBatteryVolts();
-      if (onUsbPower()) {
-        // On USB the cell is charging — the number is not a state-of-charge.
-        Serial.printf("[BATT] %.2f V (USB - charging, not SoC)\n", v);
-      } else {
-        const char* tag = v < BATT_CRITICAL_V ? "CRITICAL"
-                         : v < BATT_LOW_V     ? "LOW" : "OK";
-        Serial.printf("[BATT] %.2f V (%s)\n", v, tag);
-      }
+      const char* tag = v < BATT_CRITICAL_V ? "CRITICAL"
+                       : v < BATT_LOW_V     ? "LOW" : "OK";
+      // Always show the tag — USB is the serial link, so the bench is always on
+      // USB — and flag it: on USB the divider reads the charger, not SoC.
+      Serial.printf("[BATT] %.2f V (%s)%s\n", v, tag,
+                    onUsbPower() ? "  [USB - charging, SoC N/A]" : "");
     }
     else if (ch == 'u') {
       const bool usb = onUsbPower();
@@ -162,8 +166,7 @@ void loop() {
     g_lastStatMs = millis();
     const bool usb = onUsbPower();
     const float v  = readBatteryVolts();
-    const char* batt = usb ? "chg" : (v < BATT_CRITICAL_V ? "CRIT"
-                                     : v < BATT_LOW_V      ? "low" : "ok");
+    const char* batt = v < BATT_CRITICAL_V ? "CRIT" : v < BATT_LOW_V ? "low" : "ok";
     Serial.printf("[STAT] mist=%s duty=%u current=%.1f mA src=%s batt=%.2f V (%s)\n",
                   g_on ? "ON" : "off", g_on ? g_duty : 0,
                   readMa(20), usb ? "USB" : "BATT", v, batt);

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
@@ -110,7 +110,7 @@ static void applyOutput() {
 
 static void printHelp() {
   Serial.println("[HELP] button or t=toggle  c=current  b=battery  u=usb/mux  s=scope");
-  Serial.println("[HELP] 0..9 = duty 0..90%  h=help");
+  Serial.println("[HELP] 0..9 = output 0..90% of full drive (full = the 50%-duty sweet spot)");
   Serial.println("[HELP] handoff test: cell in -> unplug USB -> replug -> u");
 }
 

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
@@ -11,6 +11,10 @@
 //   5. "does the battery divider read?"   -> `b` prints volts + validity
 //   6. "dry vs wet separation?"           -> `s` streams CSV for the Plotter
 //   7. "does dimming work?"               -> `0`..`9` sets duty
+//   8. "does the mux hand over cleanly?"  -> cell in, mist on, unplug USB,
+//      replug, press `u`: the flip counter shows the USB->BATT->USB handoff
+//      happened, and a boot reason still reading "power-on" proves the
+//      TPS2116's ~1.3 ms break-before-make gap didn't brown out the MCU.
 //
 // The TPS2116 power mux (V0.4) runs the board off USB whenever it's plugged
 // in, so Vbatt reflects true state-of-charge only on the cell. D8 (mux ST)
@@ -31,6 +35,7 @@
 // https://github.com/owochel/MistMaker
 
 #include "pins.h"
+#include <esp_system.h>   // esp_reset_reason(): brownout vs power-on at boot
 
 static bool     g_on        = false;
 static uint8_t  g_duty      = MIST_DUTY_FULL;
@@ -40,6 +45,26 @@ static bool     g_btnRaw    = false;
 static uint32_t g_btnEdgeMs = 0;
 static uint32_t g_lastStatMs  = 0;
 static uint32_t g_lastScopeMs = 0;
+
+// Power-source handoff bookkeeping (survives USB unplug, unlike serial output):
+// the mux switches USB<->cell in ~1.3 ms with the serial link down, so we count
+// flips here and let `u` report them after the fact.
+static bool     g_lastUsb    = false;
+static uint16_t g_usbFlips   = 0;
+static uint32_t g_lastFlipMs = 0;
+
+static const char* resetReasonStr() {
+  switch (esp_reset_reason()) {
+    case ESP_RST_POWERON:   return "power-on";
+    case ESP_RST_BROWNOUT:  return "BROWNOUT";   // mux handoff gap too deep
+    case ESP_RST_SW:        return "software";
+    case ESP_RST_PANIC:     return "panic";
+    case ESP_RST_DEEPSLEEP: return "deep-sleep wake";
+    case ESP_RST_WDT: case ESP_RST_INT_WDT: case ESP_RST_TASK_WDT:
+                            return "watchdog";
+    default:                return "other";
+  }
+}
 
 static inline float adcToMa(uint16_t raw) {
   const float volts = (float(raw) * 3.3f) / 4095.0f;
@@ -86,6 +111,7 @@ static void applyOutput() {
 static void printHelp() {
   Serial.println("[HELP] button or t=toggle  c=current  b=battery  u=usb/mux  s=scope");
   Serial.println("[HELP] 0..9 = duty 0..90%  h=help");
+  Serial.println("[HELP] handoff test: cell in -> unplug USB -> replug -> u");
 }
 
 void setup() {
@@ -99,6 +125,9 @@ void setup() {
   pinMode(PIN_USB_SENSE, INPUT);     // mux ST via external divider — no pull!
   pinMode(PIN_BOOST_EN, OUTPUT);
   pinMode(PIN_STATUS_LED, OUTPUT);
+  // R8 pulls EN up to the mux rail, so the ~5 V boost rail is LIVE from
+  // power-on until this line runs (the piezo stays off — R11 holds Q4's gate
+  // down). Expected if you're scoping the rail; not a fault.
   digitalWrite(PIN_BOOST_EN, LOW);
 
   ledcAttach(PIN_MIST_PWM, MIST_FREQ_HZ, MIST_PWM_RES);
@@ -107,8 +136,10 @@ void setup() {
   Serial.println("==============================================");
   Serial.println(" Battery Kit V0.4 - BringUp");
   Serial.println("==============================================");
+  Serial.printf("[BOOT] reset: %s\n", resetReasonStr());
+  g_lastUsb = onUsbPower();
   Serial.printf("[USB] boot source: %s\n",
-                onUsbPower() ? "USB (VIN1)" : "battery (VIN2)");
+                g_lastUsb ? "USB (VIN1)" : "battery (VIN2)");
   Serial.printf("[BATT] %.2f V at boot\n", readBatteryVolts());
   printHelp();
 }
@@ -120,6 +151,17 @@ void loop() {
   if (millis() - g_btnEdgeMs > BUTTON_DEBOUNCE_MS && g_btnDeb != g_btnRaw) {
     g_btnDeb = g_btnRaw;
     if (g_btnDeb) { g_on = !g_on; applyOutput(); }   // rising edge = toggle
+  }
+
+  // ---- power-source handoff counter (ST settles in us; 50 ms rate-limit) ----
+  const bool usbNow = onUsbPower();
+  if (usbNow != g_lastUsb && millis() - g_lastFlipMs > 50) {
+    g_lastUsb = usbNow;
+    g_usbFlips++;
+    g_lastFlipMs = millis();
+    // Often unseen live (unplugging USB drops serial) — `u` replays it.
+    Serial.printf("[USB] source now %s (handoff #%u)\n",
+                  usbNow ? "USB" : "BATTERY", g_usbFlips);
   }
 
   // ---- serial commands ----
@@ -142,6 +184,17 @@ void loop() {
                     usb ? "present : mux on VIN1 (USB)"
                         : "absent  : mux on VIN2 (battery)",
                     usb ? "charging / not SoC" : "a valid SoC");
+      if (g_usbFlips) {
+        Serial.printf("[USB] handoffs since boot: %u (last at %lu ms); "
+                      "boot reset was \"%s\" -> %s\n",
+                      g_usbFlips, (unsigned long)g_lastFlipMs, resetReasonStr(),
+                      esp_reset_reason() == ESP_RST_BROWNOUT
+                          ? "handoff BROWNED OUT the MCU"
+                          : "handoff survived, no reset");
+      } else {
+        Serial.println("[USB] no handoffs seen yet - with the cell in, unplug "
+                       "and replug USB, then press u again");
+      }
     }
     else if (ch == 's') { g_scope = !g_scope;
                           Serial.printf("[CUR] scope %s\n", g_scope ? "ON" : "OFF"); }

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
@@ -1,20 +1,27 @@
-// Mist Maker Battery Kit V0.3 — BringUp sketch.
+// Mist Maker Battery Kit V0.4 — BringUp sketch.
+// (Pins D0–D7 are identical on V0.3; the `u` USB/mux test needs V0.4.)
 //
 // Bare-bones per-feature verification, no library required. Flash this on a
 // freshly assembled board and walk the checklist:
 //   1. "does the button work?"            -> press it: mist + LED toggle
-//   2. "does the boost rail come up?"     -> `t`, scope 5V5 or watch mist
+//   2. "does the boost rail come up?"     -> `t`, scope the 5 V rail or watch mist
 //   3. "is the INA180 reading anything?"  -> `c` prints one current reading
-//   4. "does the battery divider read?"   -> `b` prints volts (USB unplugged
-//                                            for a true battery reading)
-//   5. "dry vs wet separation?"           -> `s` streams CSV for the Plotter
-//   6. "does dimming work?"               -> `0`..`9` sets duty
+//   4. "which source is the mux on?"      -> `u`: plug/unplug USB, watch it flip
+//   5. "does the battery divider read?"   -> `b` prints volts + validity
+//   6. "dry vs wet separation?"           -> `s` streams CSV for the Plotter
+//   7. "does dimming work?"               -> `0`..`9` sets duty
+//
+// The TPS2116 power mux (V0.4) runs the board off USB whenever it's plugged
+// in, so Vbatt only reflects true state-of-charge when on the cell. D8 (the
+// mux ST pin) tells us which: HIGH = USB, LOW = battery — so `b` and the
+// status line only classify OK/LOW/CRITICAL when actually on the cell.
 //
 // Expected (XIAO C6, INA180A3, 30 mOhm shunt, duty 64):
 //   no disc ~0 mA · disc dry ~70-100 mA · disc in water ~130-200 mA
+//   D8: on USB reads HIGH (~2.6 V), on battery reads LOW (~0 V)
 // Battery: 4.2 V full · 3.7 V nominal · <3.45 V low · <3.20 V critical
 //
-// For real applications use the MistMaker library (>= 1.1.0) instead:
+// For real applications use the MistMaker library (>= 1.2.0) instead:
 // https://github.com/owochel/MistMaker
 
 #include "pins.h"
@@ -41,9 +48,17 @@ static float readMa(uint16_t sampleMs = 50) {
 }
 
 static float readBatteryVolts() {
-  uint32_t sum = 0;
-  for (uint8_t i = 0; i < 16; i++) sum += analogRead(PIN_BATT_ADC);
-  return (float(sum) / 16.0f) * 3.3f / 4095.0f * BATT_DIVIDER_RATIO;
+  // analogReadMilliVolts() applies the C6's factory eFuse calibration, so the
+  // reading is linear millivolts (raw analogRead is nonlinear — #11324).
+  uint32_t sum_mV = 0;
+  for (uint8_t i = 0; i < 16; i++) sum_mV += analogReadMilliVolts(PIN_BATT_ADC);
+  return (float(sum_mV) / 16.0f) / 1000.0f * BATT_DIVIDER_RATIO;
+}
+
+// Mux status on D8 (V0.4+): HIGH = load on USB (VIN1), LOW = load on the cell
+// (VIN2). Vbatt is a trustworthy state-of-charge only when this is false.
+static inline bool onUsbPower() {
+  return digitalRead(PIN_USB_SENSE) == HIGH;
 }
 
 static void applyOutput() {
@@ -63,7 +78,7 @@ static void applyOutput() {
 }
 
 static void printHelp() {
-  Serial.println("[HELP] button or t=toggle  c=current  b=battery  s=scope");
+  Serial.println("[HELP] button or t=toggle  c=current  b=battery  u=usb/mux  s=scope");
   Serial.println("[HELP] 0..9 = duty 0..90%  h=help");
 }
 
@@ -71,9 +86,11 @@ void setup() {
   Serial.begin(SERIAL_BAUD);
   delay(1000);
 
-  pinMode(PIN_CURRENT_ADC, INPUT);   // core ADC defaults — do NOT call
-  pinMode(PIN_BATT_ADC, INPUT);      // analogReadResolution() on C6 (v3.x bug)
+  pinMode(PIN_CURRENT_ADC, INPUT);   // raw analogRead for current sense; do NOT
+  pinMode(PIN_BATT_ADC, INPUT);      // call analogReadResolution() on C6 (v3.x
+                                     // bug) — battery uses analogReadMilliVolts.
   pinMode(PIN_BUTTON, INPUT);        // PCB has its own 10k pull-down
+  pinMode(PIN_USB_SENSE, INPUT);     // mux ST via external divider — no pull!
   pinMode(PIN_BOOST_EN, OUTPUT);
   pinMode(PIN_STATUS_LED, OUTPUT);
   digitalWrite(PIN_BOOST_EN, LOW);
@@ -82,8 +99,10 @@ void setup() {
   ledcWrite(PIN_MIST_PWM, 0);
 
   Serial.println("==============================================");
-  Serial.println(" Battery Kit V0.3 - BringUp");
+  Serial.println(" Battery Kit V0.4 - BringUp");
   Serial.println("==============================================");
+  Serial.printf("[USB] boot source: %s\n",
+                onUsbPower() ? "USB (VIN1)" : "battery (VIN2)");
   Serial.printf("[BATT] %.2f V at boot\n", readBatteryVolts());
   printHelp();
 }
@@ -104,9 +123,21 @@ void loop() {
     else if (ch == 'c') { Serial.printf("[CUR] %.1f mA\n", readMa()); }
     else if (ch == 'b') {
       const float v = readBatteryVolts();
-      const char* tag = v < BATT_CRITICAL_V ? "CRITICAL"
-                       : v < BATT_LOW_V     ? "LOW" : "OK";
-      Serial.printf("[BATT] %.2f V (%s)\n", v, tag);
+      if (onUsbPower()) {
+        // On USB the cell is charging — the number is not a state-of-charge.
+        Serial.printf("[BATT] %.2f V (USB - charging, not SoC)\n", v);
+      } else {
+        const char* tag = v < BATT_CRITICAL_V ? "CRITICAL"
+                         : v < BATT_LOW_V     ? "LOW" : "OK";
+        Serial.printf("[BATT] %.2f V (%s)\n", v, tag);
+      }
+    }
+    else if (ch == 'u') {
+      const bool usb = onUsbPower();
+      Serial.printf("[USB] %s  ->  battery reading is %s\n",
+                    usb ? "present : mux on VIN1 (USB)"
+                        : "absent  : mux on VIN2 (battery)",
+                    usb ? "charging / not SoC" : "a valid SoC");
     }
     else if (ch == 's') { g_scope = !g_scope;
                           Serial.printf("[CUR] scope %s\n", g_scope ? "ON" : "OFF"); }
@@ -121,15 +152,20 @@ void loop() {
   // ---- scope stream for Serial Plotter ----
   if (g_scope && millis() - g_lastScopeMs >= 10) {
     g_lastScopeMs = millis();
-    Serial.printf("mA:%.1f\tVbatt:%.2f\n",
-                  adcToMa(analogRead(PIN_CURRENT_ADC)), readBatteryVolts());
+    Serial.printf("mA:%.1f\tVbatt:%.2f\tUSB:%d\n",
+                  adcToMa(analogRead(PIN_CURRENT_ADC)), readBatteryVolts(),
+                  onUsbPower() ? 1 : 0);
   }
 
   // ---- periodic status ----
   if (!g_scope && millis() - g_lastStatMs >= 2000) {
     g_lastStatMs = millis();
-    Serial.printf("[STAT] mist=%s duty=%u current=%.1f mA batt=%.2f V\n",
+    const bool usb = onUsbPower();
+    const float v  = readBatteryVolts();
+    const char* batt = usb ? "chg" : (v < BATT_CRITICAL_V ? "CRIT"
+                                     : v < BATT_LOW_V      ? "low" : "ok");
+    Serial.printf("[STAT] mist=%s duty=%u current=%.1f mA src=%s batt=%.2f V (%s)\n",
                   g_on ? "ON" : "off", g_on ? g_duty : 0,
-                  readMa(20), readBatteryVolts());
+                  readMa(20), usb ? "USB" : "BATT", v, batt);
   }
 }

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
@@ -11,7 +11,7 @@ Per-feature hardware verification for the **Battery Kit V0.4** (pins D0–D7 are
 | press button | Button wiring — mist + LED toggle |
 | `t` | Boost rail (D3) + PWM (D0) — disc in water should mist |
 | `c` | INA180 current reading on D2 |
-| `u` | Power-mux status on D8 (V0.4) — plug/unplug USB, the source flips |
+| `u` | Power-mux status on D8 (V0.4) — reads USB present; meter TP3 for the cell case |
 | `b` | Battery divider on D1 — auto-tagged valid only when on the cell |
 | `s` | CSV stream (mA + Vbatt + USB) for the Serial Plotter |
 | `0`–`9` | Duty 0–90% dimming |
@@ -24,13 +24,15 @@ Battery: 4.2 V full · <3.45 V low · <3.20 V critical.
 
 D8 is the TPS2116 **ST** (status) pin, divided down through R21 (100K) / R22 (150K):
 
-| State | D8 | `u` / `b` report |
+| State | D8 | Meaning |
 |---|---|---|
-| USB plugged in | **HIGH** (~2.6 V) | `present : mux on VIN1 (USB)` — Vbatt is *charging*, not a state-of-charge |
-| running on cell | **LOW** (~0 V) | `absent : mux on VIN2 (battery)` — Vbatt is a **valid** state-of-charge |
+| USB plugged in | **HIGH** (~2.6 V) | mux on VIN1 (USB) — Vbatt tracks the *charger*, not SoC |
+| running on cell | **LOW** (~0 V) | mux on VIN2 (battery) — Vbatt is a **valid** state-of-charge |
 
-Because the mux runs the board off USB whenever it's plugged in, the battery voltage only means "state of charge" when D8 is LOW. `b` and the `[STAT]` line use D8 to tag the reading automatically — this is the fix for the V0.3 false low-battery shutdown.
+`b` and `[STAT]` always print the voltage + OK/LOW/CRITICAL tag, and append `[USB - charging]` when D8 is HIGH so you know the number isn't a state-of-charge. This is the basis for the library's fix to the V0.3 false low-battery shutdown.
 
+> **Serial caveat:** on this board USB *is* the serial link (native USB-Serial-JTAG), so over the console D8 essentially always reads HIGH. To confirm the LOW/cell state, meter **TP3** (or D8) with the cell in and USB out — you can't watch it flip live over serial.
+>
 > D8 must be a plain `INPUT` — the R21/R22 divider sets the level, so an internal pull would flip the reading. On V0.3 D8 is an unconnected spare, so `u` is meaningless there.
 
 Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) (≥ 1.2.0) examples — `WiFiPhoneControl` re-enables graceful low-battery shutdown, now gated on the D8 mux status.

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
@@ -1,6 +1,6 @@
 # BatteryKit_BringUp
 
-Per-feature hardware verification for the **Battery Kit V0.3**. No MistMaker library required — flash this first on a freshly assembled board.
+Per-feature hardware verification for the **Battery Kit V0.4** (pins D0–D7 are identical on V0.3; the `u` USB/mux test needs V0.4). No MistMaker library required — flash this first on a freshly assembled board.
 
 **Dependencies:** none. **Board:** XIAO ESP32-C6 (`XIAO_ESP32C6` in Tools > Board).
 
@@ -11,14 +11,26 @@ Per-feature hardware verification for the **Battery Kit V0.3**. No MistMaker lib
 | press button | Button wiring — mist + LED toggle |
 | `t` | Boost rail (D3) + PWM (D0) — disc in water should mist |
 | `c` | INA180 current reading on D2 |
-| `b` | Battery divider on D1 — unplug USB for a true pack reading |
-| `s` | CSV stream (mA + Vbatt) for the Serial Plotter |
+| `u` | Power-mux status on D8 (V0.4) — plug/unplug USB, the source flips |
+| `b` | Battery divider on D1 — auto-tagged valid only when on the cell |
+| `s` | CSV stream (mA + Vbatt + USB) for the Serial Plotter |
 | `0`–`9` | Duty 0–90% dimming |
 | `h` | Help |
 
 Expected at duty 64: no disc ≈ 0 mA · dry disc ≈ 70–100 mA · disc in water ≈ 130–200 mA.
 Battery: 4.2 V full · <3.45 V low · <3.20 V critical.
 
-> Remember: connect USB **before** the battery during development or the serial port may not enumerate.
+### The `u` test — power mux status (V0.4)
 
-Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) examples — `WiFiPhoneControl` includes the graceful low-battery shutdown.
+D8 is the TPS2116 **ST** (status) pin, divided down through R21 (100K) / R22 (150K):
+
+| State | D8 | `u` / `b` report |
+|---|---|---|
+| USB plugged in | **HIGH** (~2.6 V) | `present : mux on VIN1 (USB)` — Vbatt is *charging*, not a state-of-charge |
+| running on cell | **LOW** (~0 V) | `absent : mux on VIN2 (battery)` — Vbatt is a **valid** state-of-charge |
+
+Because the mux runs the board off USB whenever it's plugged in, the battery voltage only means "state of charge" when D8 is LOW. `b` and the `[STAT]` line use D8 to tag the reading automatically — this is the fix for the V0.3 false low-battery shutdown.
+
+> D8 must be a plain `INPUT` — the R21/R22 divider sets the level, so an internal pull would flip the reading. On V0.3 D8 is an unconnected spare, so `u` is meaningless there.
+
+Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) (≥ 1.2.0) examples — `WiFiPhoneControl` re-enables graceful low-battery shutdown, now gated on the D8 mux status.

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
@@ -15,6 +15,7 @@ Per-feature hardware verification for the **Battery Kit V0.4** (pins D0–D7 are
 | `b` | Battery divider on D1 — auto-tagged valid only when on the cell |
 | `s` | CSV stream (mA + Vbatt + USB) for the Serial Plotter |
 | `0`–`9` | Duty 0–90% dimming |
+| unplug USB, replug, `u` | **Mux handoff** — flip counter + boot reason prove the USB↔cell switchover didn't reset the MCU |
 | `h` | Help |
 
 Expected at duty 64: no disc ≈ 0 mA · dry disc ≈ 70–100 mA · disc in water ≈ 130–200 mA.
@@ -34,5 +35,20 @@ D8 is the TPS2116 **ST** (status) pin, divided down through R21 (100K) / R22 (15
 > **Serial caveat:** on this board USB *is* the serial link (native USB-Serial-JTAG), so over the console D8 essentially always reads HIGH. To confirm the LOW/cell state, meter **TP3** (or D8) with the cell in and USB out — you can't watch it flip live over serial.
 >
 > D8 must be a plain `INPUT` — the R21/R22 divider sets the level, so an internal pull would flip the reading. On V0.3 D8 is an unconnected spare, so `u` is meaningless there.
+
+### The handoff test — live unplug/replug (V0.4)
+
+The TPS2116 switches sources **break-before-make**: for ~1.3 ms neither input drives the rail, and the board must ride through on its capacitors (the 3.3 V handoff also involves Q1 re-enabling the onboard LDO). The sketch counts every USB↔cell flip in RAM and prints the **reset reason** at boot, so the test works even though serial dies while unplugged:
+
+1. Cell plugged in, mist running (`t`), USB connected.
+2. Unplug USB — mist should keep running from the cell. Wait a few seconds.
+3. Replug USB, reopen serial, press `u`.
+4. **Pass:** handoff count ≥ 2 and boot reset still reads `power-on` (a fresh `BROWNOUT` line means the gap dipped too deep — check C6/C12/C15 soldering).
+
+### Power notes (as-built V0.4, June 2026 run)
+
+- The ~5 V boost rail is **live from power-on** (R8 pulls the TPS61023 EN high) until the sketch drives D3 low in `setup()`. The piezo stays off regardless (R11 holds the MOSFET gate down) — don't be surprised by 5 V on a scope before boot.
+- Charge current is **~196 mA** (R6 = 5.1 kΩ on the LP4060) — a deliberate thermal derate from the 500 mA design. LED1 (green) lit = charging; a 500 mAh cell takes ≈ 3 h from empty.
+- The battery divider (R18/R19) is hard-wired and draws a constant **~210 µA** from the cell — negligible in use, but don't expect shelf-storage battery life with a cell left plugged in.
 
 Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) (≥ 1.2.0) examples — `WiFiPhoneControl` re-enables graceful low-battery shutdown, now gated on the D8 mux status.

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/pins.h
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/pins.h
@@ -1,18 +1,22 @@
-// Mist Maker Battery Kit V0.3 — pin map + hardware constants.
+// Mist Maker Battery Kit V0.4 — pin map + hardware constants.
+// (D0–D7 are identical on V0.3; V0.4 adds the power-mux status sense on D8.)
 //
-// Single-PCB portable variant: LiPo + USB-C charging (MCP73831), TPS61023
-// boost for the piezo rail, INA180A3 current sense, button, status LED, and
-// (new in V0.3) a resistor divider on D1 to read the battery voltage.
+// Single-PCB portable variant: LiPo + USB-C charging (LP4060), TPS2116 power
+// mux (USB-priority), TPS61023 boost for the piezo rail, INA180A3 current
+// sense, button, status LED, a resistor divider on D1 to read the battery,
+// and (new in V0.4) the TPS2116 STATUS pin on D8 so firmware can tell whether
+// the load is running from USB or from the cell.
 //
-// KiCad nets -> pins (MistMaker-Battery-Kit-V0-3.kicad_sch):
-//   MIST_PWM_3V3    -> D0   108.7 kHz PWM to MOSFET gate
-//   D1_BATT_VOLTAGE -> D1   battery via divider (V0.3+ only)
+// KiCad nets -> pins (MistMaker-Battery-Kit-V0-4.kicad_sch):
+//   MIST_PWM_3V3    -> D0   108.7 kHz PWM to the gate driver
+//   D1_BATT_VOLTAGE -> D1   battery via 10k/10k divider (ratio 2.0)
 //   D2_CS           -> D2   INA180A3 current-sense output
-//   D3_TPS_EN       -> D3   TPS61023 EN (HIGH = 5.5 V rail on)
-//   D4_SDA / D5_SCL -> D4/D5  I2C breakout
+//   D3_TPS_EN       -> D3   TPS61023 EN (HIGH = ~5 V boost rail on)
+//   D4_SDA / D5_SCL -> D4/D5  I2C (Qwiic)
 //   D6_BUTTON       -> D6   active-HIGH, PCB 10k pull-down
 //   D7_LED          -> D7   status LED
-//   D8/D9/D10       ->      spare breakout
+//   D8_ST           -> D8   TPS2116 STATUS (V0.4+): HIGH = on USB, LOW = on cell
+//   D9/D10          ->      spare breakout
 
 #pragma once
 #include <Arduino.h>
@@ -25,6 +29,13 @@
   constexpr uint8_t PIN_BOOST_EN    = D3;
   constexpr uint8_t PIN_BUTTON      = D6;
   constexpr uint8_t PIN_STATUS_LED  = D7;
+  // TPS2116 STATUS pin, level-shifted through R21/R22 onto net D8_ST (V0.4+).
+  //   HIGH (~2.6 V) -> mux sourcing VIN1 = USB present; the cell is charging.
+  //   LOW  (~0 V)   -> mux sourcing VIN2 = running on the cell; Vbatt = true SoC.
+  // Plain INPUT only: the external divider defines the level; an internal
+  // pull-up/down would swamp it and flip the reading. (On V0.3, D8 is an
+  // unconnected spare, so the USB/mux test is V0.4+ only.)
+  constexpr uint8_t PIN_USB_SENSE   = D8;
 #else
   #error "Battery Kit V0.3 firmware: select a XIAO ESP32 board in Tools > Board."
 #endif
@@ -37,7 +48,9 @@ constexpr uint8_t  MIST_DUTY_FULL = 127;     // 50% — resonant sweet spot
 // INA180A3 current sense: V per A = gain (100 V/V) x shunt (30 mOhm)
 constexpr float CURRENT_SENSE_FACTOR = 3.0f;
 
-// Battery divider: Vbatt = Vpin x ratio. V0.3 uses equal resistors -> 2.0.
+// Battery divider: Vbatt = Vpin x ratio. V0.3/V0.4 use equal 10k/10k -> 2.0.
+// The battery read uses analogReadMilliVolts() for the C6's calibrated ADC
+// (raw analogRead is nonlinear on C6 v3.x — arduino-esp32 #11324).
 constexpr float BATT_DIVIDER_RATIO = 2.0f;
 
 // LiPo guidance (under load): warn below LOW, shut down below CRITICAL.

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -256,6 +256,7 @@ static void printHelp() {
 #if defined(BOARD_BATTERY_KIT_V04)
   Serial.println("[HELP] B=arm battery sweep (unplug USB after arming)");
 #endif
+  Serial.println("[HELP] r=reprint last stored sweep table");
   Serial.println("[HELP] 0..9=duty n*10%  +/-=nudge  s=stream  x=off  h=help");
 }
 
@@ -303,16 +304,12 @@ void setup() {
     } else Serial.println("[U] cancelled.");
   }
 
-  // Black box from a previous unattended sweep? Replay it.
-  if (prefs.getBytes("blog", &g_log, sizeof(g_log)) == sizeof(g_log) && g_log.unread && g_log.count) {
-    printLogTable("[LOG] ==== sweep results (from flash) ====");
-    if (!g_log.done && rr == ESP_RST_BROWNOUT)
-      Serial.println("[LOG] the sweep itself browned the board out — that step is the wall.");
-    if (!g_log.done && rr == ESP_RST_POWERON)
-      Serial.println("[LOG] power was CUT mid-sweep (USB port breaker?) — that step is the wall.");
-    g_log.unread = 0;
-    saveLog();
-  }
+  // Load the black box but do NOT print-and-mark-read at boot: on native-USB
+  // boards setup() runs before any serial monitor attaches, so a boot-time
+  // replay prints into the void and flags the table read unseen (that also
+  // happened right after a 'U' sweep on a wall brick — same boot, same bug).
+  // loop() replays once a monitor is actually connected; 'r' reprints anytime.
+  prefs.getBytes("blog", &g_log, sizeof(g_log));
 
   Serial.println("[!] Disc must be IN WATER before you start.");
   printHelp();
@@ -333,12 +330,17 @@ void loop() {
   }
 #endif
 
-  // Replay results the moment serial + USB are back and a table is unread.
+  // Replay results once a serial MONITOR is attached (bool(Serial) = host
+  // opened the port on native-USB boards) and a table is unread. This is the
+  // only place unread gets cleared — a print nobody could see doesn't count.
   static uint32_t lastReplayCheck = 0;
-  if (onUsb() && millis() - lastReplayCheck > 1000) {
+  if (millis() - lastReplayCheck > 1000) {
     lastReplayCheck = millis();
-    if (g_log.unread && g_log.count && g_log.done) {
+    if (g_log.unread && g_log.count && (bool)Serial) {
       printLogTable("[LOG] ==== sweep results ====");
+      if (!g_log.done)
+        Serial.println("[LOG] sweep did not finish — power was lost or the board "
+                       "reset mid-sweep; the last row is the wall.");
       g_log.unread = 0;
       saveLog();
     }
@@ -371,6 +373,11 @@ void loop() {
       prefs.putUChar("lim", g_limitIdx);         // survives reboot/power-cycle
       Serial.printf("[CFG] current limit -> %.0f mA%s\n", limitMa(),
                     g_limitIdx == 2 ? "  (D1's 1 A rating — short steps only, watch L1!)" : "");
+    }
+    else if (ch == 'r') {                        // reprint stored table, any state
+      if (prefs.getBytes("blog", &g_log, sizeof(g_log)) == sizeof(g_log) && g_log.count)
+        printLogTable("[LOG] ==== last sweep stored in flash ====");
+      else Serial.println("[LOG] no sweep stored yet.");
     }
     else if (ch == 'x') { g_armedBatt = false; prefs.putUChar("armU", 0); setDuty(0); }
     else if (ch == 's') { g_stream = !g_stream;

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -1,71 +1,102 @@
-// DutySweep_Test — does mist output really peak at ~50% PWM duty?
+// DutySweep_Test — how much mist can the V0.4 board actually make?
 //
-// The MistMaker library caps duty at 127/255 (50%) on the theory that a
-// single-transistor resonant drive makes the most mist there and only makes
-// more HEAT beyond it. This sketch bypasses the library and sweeps the raw
-// LEDC duty 0 -> 100% so you can verify that on real hardware.
+// v1 asked "does mist peak at 50% duty?" — bench answer (2026-07-03): NO,
+// mist keeps rising past 50% on this flyback-style drive, but current goes
+// superlinear (224 mA @50% -> 1.1 A @75%), L1 runs hot by ~62%, and ~1.5 A
+// total USB draw at 75% sags VBUS into a brownout (TPS2116 drops USB below
+// 4.0 V). So the USB port, not the circuit, set the ceiling.
 //
-// What to watch (your eyes are the mist sensor, the board logs the rest):
-//   * If the 50% theory holds: visible mist rises up to ~duty 120-140, then
-//     FLATTENS or DROPS — while input current KEEPS RISING. Current up +
-//     mist down = the extra duty is turning into transistor/tank heat.
-//   * If mist keeps clearly increasing past 60-70% duty, the cap is wrong
-//     for this board and we should raise the library default.
+// v2 adds the tools to push past that ceiling safely:
+//   * runtime current limit (`L` cycles 600 -> 900 -> 1200 mA). 1200 is the
+//     hard max: D1 (PMEG10010, series Schottky in the drive feed) is rated
+//     1 A continuous — brief steps above it are survivable, parking is not.
+//   * BATTERY SWEEP (`B`): the cell can source what USB can't. Arm it over
+//     serial, unplug USB, and the board runs the sweep unattended from the
+//     cell (duty 50 -> 90%), logging every step to flash (NVS) so even a
+//     brownout can't lose the data. Replug USB — the table replays.
+//     Guards: current > 1.2 A, loaded Vbatt < 3.5 V (the 3V3 LDO drops out
+//     ~3.65 V — abort before the XIAO browns out), USB replug mid-sweep.
+//   * duty hard-cap 230/255 (~90%) everywhere: at 108.7 kHz the period is
+//     9.2 us and the resonant ring-back needs ~4.6 us of off-time — above
+//     ~90% there is no ring, no mist, and L1 becomes a DC heater. 100% duty
+//     is a short circuit with extra steps, not "max mist".
 //
-// BENCH RESULT (V0.4 board, 2026-07-03): mist kept INCREASING past 50% —
-// but current went superlinear (224 mA @50% -> 1.1 A @75%, ~5x power for
-// the gain: inductor saturation territory), and at ~75% total USB draw hit
-// ~1.5 A, VBUS sagged, and the board BROWNED OUT mid-sweep (the banner
-// reprinting = reboot; the TPS2116 drops USB when VBUS < 4.0 V). So 50%
-// is the efficiency/stability knee, not a mist maximum. The sweep now
-// aborts above SWEEP_ABORT_MA to fail gracefully instead of rebooting.
+// Thermal protocol: L1 is hot to touch from ~485 mA. High-duty steps dwell
+// only ~1.5 s with an off-cooldown between; let the board rest a minute or
+// two between full runs, and touch-check L1. Disc IN WATER, always.
 //
-// Setup: Battery Kit V0.4 (or V0.3 — same D0/D2/D3), disc IN WATER (never
-// sweep a dry disc), USB serial @ 115200. Best in still air, good light.
-//
-// Commands:
-//   w        run the automatic sweep (0 -> 100% in 16 steps, ~3 s each,
-//            current logged per step, summary table at the end)
-//   0..9     hold duty at n*10% (e.g. 5 = 50%) for manual A/B comparison
-//   + / -    nudge duty by 4 counts
-//   s        toggle CSV stream (duty + mA) for the Serial Plotter
-//   x        everything off
-//
-// Safety: steps above ~60% run the FET/boost hotter than the design point —
-// the sweep dwells only 3 s per step and shuts off when done. Don't park at
-// high duty for minutes. If anything smells hot, hit 'x'.
+// Commands (serial 115200):
+//   w        USB sweep 0 -> 90% (~3 s/step, aborts at the current limit)
+//   B        arm the battery sweep, then unplug USB within 30 s
+//   L        cycle the current limit: 600 / 900 / 1200 mA
+//   0..9     hold duty at n*10% (capped at 90%)   + / -  nudge by 4
+//   s        CSV stream (duty, mA, Vbatt, USB) for the Serial Plotter
+//   x        everything off / disarm    h  help
 
 #include <Arduino.h>
-#include <esp_system.h>   // esp_reset_reason(): names a brownout after the fact
+#include <esp_system.h>    // esp_reset_reason(): names a brownout after the fact
+#include <Preferences.h>   // NVS: battery-sweep black box, survives any reset
 
 #if defined(ARDUINO_XIAO_ESP32C6) || defined(ARDUINO_XIAO_ESP32S3) || \
     defined(ARDUINO_XIAO_ESP32S3_PLUS) || defined(ARDUINO_XIAO_ESP32C3)
   constexpr uint8_t PIN_MIST_PWM    = D0;   // gate driver input
+  constexpr uint8_t PIN_BATT_ADC    = D1;   // battery via 10k/10k divider
   constexpr uint8_t PIN_CURRENT_ADC = D2;   // INA180A3 out (3.0 V per A)
   constexpr uint8_t PIN_BOOST_EN    = D3;   // TPS61023 EN (HIGH = 5V rail on)
+  constexpr uint8_t PIN_USB_SENSE   = D8;   // TPS2116 ST: HIGH = USB, LOW = cell
 #else
   #error "Select a XIAO ESP32 board in Tools > Board."
 #endif
 
-constexpr uint32_t MIST_FREQ_HZ = 108700;
-constexpr uint8_t  PWM_RES_BITS = 8;              // duty 0..255
-constexpr float    SENSE_V_PER_A = 3.0f;          // INA180A3 (100 V/V) x 30 mOhm
+constexpr uint32_t MIST_FREQ_HZ  = 108700;
+constexpr uint8_t  PWM_RES_BITS  = 8;
+constexpr float    SENSE_V_PER_A = 3.0f;    // INA180A3 (100 V/V) x 30 mOhm
+constexpr float    BATT_DIVIDER  = 2.0f;    // 10k/10k
 
-constexpr uint8_t  SWEEP_STEPS    = 16;           // 0..255 in 17 points
-constexpr uint16_t SWEEP_DWELL_MS = 3000;         // per step
-constexpr uint16_t SWEEP_SETTLE_MS = 1500;        // dwell before sampling starts
-// Abort the sweep above this drive current. Bench (2026-07-03): L1 (the 3-leg
-// autotransformer) is already hot to touch at ~485 mA / 62% duty, and ~1.1 A
-// / 75% duty sagged USB VBUS into a brownout reset. 600 mA keeps the sweep in
-// "informative but not self-destructive" territory; raise it deliberately if
-// you're on a beefy supply and watching L1's temperature.
-constexpr float SWEEP_ABORT_MA = 600.0f;
+// ~90% of 255. Above this the off-window can't fit the resonant ring-back:
+// no mist, just DC heating in L1. Applies to sweeps AND manual duty.
+constexpr uint8_t DUTY_HARD_MAX = 230;
 
-static uint8_t  g_duty  = 0;
+// USB sweep (attended, ~3 s/step)
+constexpr uint8_t  SWEEP_STEPS     = 16;
+constexpr uint16_t SWEEP_DWELL_MS  = 3000;
+constexpr uint16_t SWEEP_SETTLE_MS = 1500;
+
+// Battery sweep (unattended): duty 127 -> 230 in 13-count steps, short dwell
+// + off-cooldown to keep L1 survivable at the currents involved.
+constexpr uint8_t  BSWEEP_START    = 127;
+constexpr uint8_t  BSWEEP_STEP     = 13;
+constexpr uint16_t BSWEEP_SETTLE_MS   = 500;
+constexpr uint16_t BSWEEP_SAMPLE_MS   = 1000;
+constexpr uint16_t BSWEEP_COOLDOWN_MS = 1000;
+constexpr uint32_t BSWEEP_ARM_TIMEOUT_MS = 30000;
+constexpr float    BSWEEP_MIN_VBATT = 3.50f;  // loaded; LDO dropout ~3.65 V
+constexpr uint8_t  BSWEEP_MAX_STEPS = 10;
+
+constexpr float LIMIT_STEPS_MA[] = { 600.0f, 900.0f, 1200.0f };  // 1200 = D1's edge
+
+static uint8_t  g_duty = 0;
 static bool     g_stream = false;
 static uint32_t g_lastStreamMs = 0;
+static uint8_t  g_limitIdx = 0;
+static bool     g_armed = false;
+static uint32_t g_armedAtMs = 0;
+Preferences prefs;
 
-// mA from the INA180. analogReadMilliVolts = factory-calibrated, linear on C6.
+struct BsweepLog {                 // black box, one NVS blob
+  uint8_t  count;                  // steps recorded
+  uint8_t  done;                   // 1 = sweep finished cleanly
+  uint8_t  unread;                 // 1 = not yet replayed over serial
+  uint8_t  abortReason;            // 0 ok, 1 overcurrent, 2 vbatt, 3 usb-replug
+  uint8_t  duty[BSWEEP_MAX_STEPS];
+  float    ma[BSWEEP_MAX_STEPS];
+  float    vb[BSWEEP_MAX_STEPS];
+};
+static BsweepLog g_log;
+
+static float limitMa() { return LIMIT_STEPS_MA[g_limitIdx]; }
+static bool  onUsb()   { return digitalRead(PIN_USB_SENSE) == HIGH; }
+
 static float readMa(uint16_t sampleMs) {
   uint32_t sum_mV = 0, n = 0;
   const uint32_t t0 = millis();
@@ -73,93 +104,206 @@ static float readMa(uint16_t sampleMs) {
   return n ? (float(sum_mV) / n) / SENSE_V_PER_A : 0.0f;   // mV / (V/A) = mA
 }
 
+static float readVbatt() {
+  uint32_t sum_mV = 0;
+  for (uint8_t i = 0; i < 16; i++) sum_mV += analogReadMilliVolts(PIN_BATT_ADC);
+  return (float(sum_mV) / 16.0f) / 1000.0f * BATT_DIVIDER;
+}
+
 static void setDuty(uint8_t d) {
+  if (d > DUTY_HARD_MAX) {
+    Serial.printf("[DUTY] %u capped to %u (~90%%): past that the ring-back has no\n"
+                  "[DUTY] time to swing — no mist, L1 just heats as a DC load.\n",
+                  d, DUTY_HARD_MAX);
+    d = DUTY_HARD_MAX;
+  }
   g_duty = d;
   digitalWrite(PIN_BOOST_EN, d > 0 ? HIGH : LOW);
-  if (d > 0) delayMicroseconds(500);               // rail settle on first turn-on
+  if (d > 0) delayMicroseconds(500);
   ledcWrite(PIN_MIST_PWM, d);
   Serial.printf("[DUTY] %3u/255 = %5.1f%%\n", d, d * 100.0f / 255.0f);
 }
 
+static void saveLog() { prefs.putBytes("blog", &g_log, sizeof(g_log)); }
+
+static void printBsweepTable(const char* header) {
+  Serial.println();
+  Serial.println(header);
+  Serial.println("[BATT]  duty%   drive-mA   Vbatt");
+  for (uint8_t i = 0; i < g_log.count; i++)
+    Serial.printf("[BATT]  %5.1f   %7.1f   %5.2f V\n",
+                  g_log.duty[i] * 100.0f / 255.0f, g_log.ma[i], g_log.vb[i]);
+  const char* why = g_log.abortReason == 1 ? "current limit (D1 rating)"
+                  : g_log.abortReason == 2 ? "cell sagged (LDO dropout guard)"
+                  : g_log.abortReason == 3 ? "USB replugged mid-sweep"
+                  : g_log.done             ? "completed full range"
+                                           : "DID NOT FINISH (reset mid-sweep?)";
+  Serial.printf("[BATT] end: %s\n", why);
+}
+
+// ---------------- USB (attended) sweep ----------------
 static void sweep() {
   Serial.println();
-  Serial.println("[SWEEP] 0 -> 100% duty. WATCH THE MIST at each step and note");
-  Serial.println("[SWEEP] where it stops getting denser. ~3 s per step.");
+  Serial.printf("[SWEEP] 0 -> 90%% duty, limit %.0f mA ('L' raises it). WATCH THE MIST.\n", limitMa());
   Serial.println("[SWEEP]  step   duty    duty%   current");
 
   float ma[SWEEP_STEPS + 1];
   uint8_t duties[SWEEP_STEPS + 1];
-  uint8_t ran = 0;                                 // steps actually measured
+  uint8_t ran = 0;
 
   for (uint8_t i = 0; i <= SWEEP_STEPS; i++) {
-    const uint8_t d = (uint8_t)((uint16_t)i * 255 / SWEEP_STEPS);
+    uint8_t d = (uint8_t)((uint16_t)i * 255 / SWEEP_STEPS);
+    if (d > DUTY_HARD_MAX) d = DUTY_HARD_MAX;
     duties[i] = d;
     digitalWrite(PIN_BOOST_EN, HIGH);
     ledcWrite(PIN_MIST_PWM, d);
-    delay(SWEEP_SETTLE_MS);                        // let drive + water column respond
+    delay(SWEEP_SETTLE_MS);
     ma[i] = readMa(SWEEP_DWELL_MS - SWEEP_SETTLE_MS);
     ran = i + 1;
     Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA\n",
                   i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i]);
-    if (ma[i] > SWEEP_ABORT_MA) {
-      Serial.printf("[SWEEP] %.0f mA > %.0f mA limit — stopping here. Past this\n"
-                    "[SWEEP] point L1 saturates (runs hot) and USB VBUS sag can\n"
-                    "[SWEEP] brown-out the board. Raise SWEEP_ABORT_MA to explore.\n",
-                    ma[i], SWEEP_ABORT_MA);
+    if (ma[i] > limitMa()) {
+      Serial.printf("[SWEEP] %.0f mA > %.0f mA limit — stopping. 'L' raises the limit\n"
+                    "[SWEEP] (max 1200 mA = D1's rating); 'B' sweeps from the battery\n"
+                    "[SWEEP] instead, which dodges the USB brownout entirely.\n",
+                    ma[i], limitMa());
       break;
     }
     if (Serial.available() && Serial.read() == 'x') { Serial.println("[SWEEP] aborted"); break; }
+    if (duties[i] == DUTY_HARD_MAX) break;
   }
   setDuty(0);
 
-  // Summary: current alone can't see the mist peak (current keeps rising past
-  // it) — so print the table for pairing with what you SAW.
   Serial.println();
   Serial.println("[RESULT] duty%, mA   (paste next to your mist notes)");
   for (uint8_t i = 0; i < ran; i++)
     Serial.printf("%5.1f, %.1f\n", duties[i] * 100.0f / 255.0f, ma[i]);
-  Serial.println();
-  Serial.println("[RESULT] Reading it: if current rose monotonically but mist");
-  Serial.println("[RESULT] peaked near 50%, the library's 127 cap is correct.");
-  Serial.println("[RESULT] If mist tracked current all the way up, tell Claude");
-  Serial.println("[RESULT] — the cap should be raised.");
+}
+
+// ---------------- battery (unattended) sweep ----------------
+// Runs with serial dead. Every step lands in NVS before the next begins, so
+// the table survives a brownout, a cell collapse, or a mid-sweep reset.
+static void batterySweep() {
+  memset(&g_log, 0, sizeof(g_log));
+  g_log.unread = 1;
+  saveLog();
+
+  for (uint8_t i = 0; i < BSWEEP_MAX_STEPS; i++) {
+    uint16_t d16 = BSWEEP_START + (uint16_t)i * BSWEEP_STEP;
+    const uint8_t d = d16 > DUTY_HARD_MAX ? DUTY_HARD_MAX : (uint8_t)d16;
+
+    digitalWrite(PIN_BOOST_EN, HIGH);
+    ledcWrite(PIN_MIST_PWM, d);
+    delay(BSWEEP_SETTLE_MS);
+    const float ma = readMa(BSWEEP_SAMPLE_MS);
+    const float vb = readVbatt();               // still under load
+
+    g_log.duty[i] = d; g_log.ma[i] = ma; g_log.vb[i] = vb;
+    g_log.count = i + 1;
+
+    if      (ma > limitMa())          g_log.abortReason = 1;
+    else if (vb < BSWEEP_MIN_VBATT)   g_log.abortReason = 2;
+    else if (onUsb())                 g_log.abortReason = 3;
+    saveLog();                                   // step is safe in flash NOW
+
+    ledcWrite(PIN_MIST_PWM, 0);                  // off-cooldown for L1
+    delay(BSWEEP_COOLDOWN_MS);
+
+    if (g_log.abortReason || d == DUTY_HARD_MAX) break;
+  }
+  g_log.done = 1;
+  saveLog();
+  ledcWrite(PIN_MIST_PWM, 0);
+  digitalWrite(PIN_BOOST_EN, LOW);
 }
 
 static void printHelp() {
-  Serial.println("[HELP] w=auto sweep  0..9=hold n*10% duty  +/-=nudge  s=stream  x=off");
+  Serial.printf("[HELP] w=USB sweep  B=arm battery sweep  L=limit (now %.0f mA)\n", limitMa());
+  Serial.println("[HELP] 0..9=duty n*10%  +/-=nudge  s=stream  x=off  h=help");
+  Serial.println("[HELP] battery sweep: press B, unplug USB, watch mist, replug, read table");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
   pinMode(PIN_CURRENT_ADC, INPUT);
+  pinMode(PIN_BATT_ADC, INPUT);
+  pinMode(PIN_USB_SENSE, INPUT);     // external divider — no internal pull!
   pinMode(PIN_BOOST_EN, OUTPUT);
   digitalWrite(PIN_BOOST_EN, LOW);
   ledcAttach(PIN_MIST_PWM, MIST_FREQ_HZ, PWM_RES_BITS);
   ledcWrite(PIN_MIST_PWM, 0);
 
+  prefs.begin("dsweep");
+
   Serial.println("==============================================");
-  Serial.println(" Duty Sweep - does mist peak at 50% duty?");
+  Serial.println(" Duty Sweep v2 - find the V0.4 board's max");
   Serial.println("==============================================");
-  // If the previous run ended in a mid-sweep reboot, this line names it:
-  // "brownout" = the supply sagged under the high-duty load.
   const esp_reset_reason_t rr = esp_reset_reason();
   Serial.printf("[BOOT] reset: %s\n",
                 rr == ESP_RST_BROWNOUT ? "BROWNOUT (supply sagged under load!)"
                 : rr == ESP_RST_POWERON ? "power-on"
                 : rr == ESP_RST_SW      ? "software" : "other");
+
+  // Black box from a previous battery sweep? Replay it.
+  if (prefs.getBytes("blog", &g_log, sizeof(g_log)) == sizeof(g_log) && g_log.unread && g_log.count) {
+    printBsweepTable("[BATT] ==== battery sweep results (from flash) ====");
+    if (!g_log.done && rr == ESP_RST_BROWNOUT)
+      Serial.println("[BATT] the sweep itself browned the board out — that step is the wall.");
+    g_log.unread = 0;
+    saveLog();
+  }
+
   Serial.println("[!] Disc must be IN WATER before you start.");
   printHelp();
 }
 
 void loop() {
+  // Armed battery sweep: wait for the unplug, then run unattended.
+  if (g_armed) {
+    if (!onUsb()) {
+      delay(2000);                               // let the unplug settle
+      batterySweep();
+      g_armed = false;                           // done; table prints on replug/reboot
+    } else if (millis() - g_armedAtMs > BSWEEP_ARM_TIMEOUT_MS) {
+      g_armed = false;
+      Serial.println("[BATT] arm timed out (30 s) — press B and unplug sooner.");
+    }
+  }
+
+  // Replay results the moment serial + USB are back and a table is unread.
+  static uint32_t lastReplayCheck = 0;
+  if (onUsb() && millis() - lastReplayCheck > 1000) {
+    lastReplayCheck = millis();
+    if (g_log.unread && g_log.count && g_log.done) {
+      printBsweepTable("[BATT] ==== battery sweep results ====");
+      g_log.unread = 0;
+      saveLog();
+    }
+  }
+
   while (Serial.available()) {
     const char ch = Serial.read();
     if      (ch == 'w') sweep();
-    else if (ch == 'x') setDuty(0);
+    else if (ch == 'B') {
+      if (!onUsb()) { Serial.println("[BATT] already on battery — plug USB in, then arm."); }
+      else {
+        g_armed = true; g_armedAtMs = millis();
+        Serial.printf("[BATT] ARMED (limit %.0f mA, floor %.2f V, duty 50->90%%).\n",
+                      limitMa(), BSWEEP_MIN_VBATT);
+        Serial.println("[BATT] Unplug USB within 30 s. Watch the mist per step (~2.5 s each).");
+        Serial.println("[BATT] Replug when the mist stops — the table replays here.");
+      }
+    }
+    else if (ch == 'L') {
+      g_limitIdx = (g_limitIdx + 1) % (sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0]));
+      Serial.printf("[CFG] current limit -> %.0f mA%s\n", limitMa(),
+                    g_limitIdx == 2 ? "  (D1's 1 A rating — short steps only, watch L1!)" : "");
+    }
+    else if (ch == 'x') { g_armed = false; setDuty(0); }
     else if (ch == 's') { g_stream = !g_stream;
                           Serial.printf("[CFG] stream %s\n", g_stream ? "ON" : "OFF"); }
-    else if (ch == '+') setDuty(g_duty <= 251 ? g_duty + 4 : 255);
+    else if (ch == '+') setDuty(g_duty + 4 > DUTY_HARD_MAX ? DUTY_HARD_MAX : g_duty + 4);
     else if (ch == '-') setDuty(g_duty >= 4 ? g_duty - 4 : 0);
     else if (ch >= '0' && ch <= '9') setDuty((uint8_t)((ch - '0') * 255 / 10));
     else if (ch == 'h') printHelp();
@@ -167,6 +311,7 @@ void loop() {
 
   if (g_stream && millis() - g_lastStreamMs >= 100) {
     g_lastStreamMs = millis();
-    Serial.printf("duty:%u\tmA:%.1f\n", g_duty, readMa(50));
+    Serial.printf("duty:%u\tmA:%.1f\tVbatt:%.2f\tUSB:%d\n",
+                  g_duty, readMa(50), readVbatt(), onUsb() ? 1 : 0);
   }
 }

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -52,14 +52,14 @@
   constexpr uint8_t PIN_CURRENT_ADC = D2;    // INA180A3 (5 V rail -> ~1.55 A range)
   constexpr int8_t  PIN_BOOST_EN    = D3;    // TPS61023 EN
   constexpr int8_t  PIN_USB_SENSE   = D8;    // TPS2116 ST: HIGH = USB
-  constexpr float   SENSE_SAT_MA    = 1550.0f;
+  constexpr float   SENSE_SAT_MA    = 1050.0f;
 #elif defined(BOARD_EXTENSION_KIT_V01)
   constexpr uint8_t PIN_MIST_PWM    = D0;
   constexpr int8_t  PIN_BATT_ADC    = -1;    // no cell
   constexpr uint8_t PIN_CURRENT_ADC = D2;    // INA180A3 (3V3 rail -> saturates ~1.05 A)
   constexpr int8_t  PIN_BOOST_EN    = -1;    // piezo rail = VBUS, always on
   constexpr int8_t  PIN_USB_SENSE   = -1;    // no mux
-  constexpr float   SENSE_SAT_MA    = 1000.0f;
+  constexpr float   SENSE_SAT_MA    = 1050.0f;
 #else
   #error "Uncomment one BOARD_* define above."
 #endif
@@ -124,7 +124,10 @@ static float readMa(uint16_t sampleMs) {
   while (millis() - t0 < sampleMs) { sum_mV += analogReadMilliVolts(PIN_CURRENT_ADC); n++; }
   return n ? (float(sum_mV) / n) / SENSE_V_PER_A : 0.0f;   // mV / (V/A) = mA
 }
-// "sat!" = at/above the sense amp's output ceiling — real current is HIGHER.
+// "sat!" = at/above the measurement ceiling — real current is HIGHER. On BOTH
+// boards the ESP32 ADC pin (~3.3 V full scale = ~1.1 A at 3.0 V/A) pins before
+// the INA180 does; bench-confirmed readings plateau at ~1100 mA while an
+// inline USB meter showed ~1.9 A of real drive current at 80-85% duty.
 static const char* satFlag(float ma) { return ma >= SENSE_SAT_MA * 0.97f ? " sat!" : ""; }
 
 static float readVbatt() {

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -97,6 +97,11 @@ static uint32_t g_lastStreamMs = 0;
 static uint8_t  g_limitIdx = 0;
 static bool     g_armedBatt = false;
 static uint32_t g_armedAtMs = 0;
+// 'U' with a cell attached: the board never reboots on unplug (the mux hands
+// off to the cell), so "next boot" never comes. Instead we watch for USB to
+// LEAVE and COME BACK — that's the move to the wall brick.
+static bool     g_armUPending = false;
+static bool     g_sawUsbDrop  = false;
 Preferences prefs;
 
 struct SweepLog {                  // black box, one NVS blob
@@ -208,11 +213,14 @@ static void sweep() {
     Serial.printf("%5.1f, %.1f%s\n", duties[i] * 100.0f / 255.0f, ma[i], satFlag(ma[i]));
 }
 
-// ---------------- unattended sweep (battery 'B' / on-boot 'U') ----------------
+// ---------------- unattended sweep (battery 'B' / 'U') ----------------
 // Runs with serial dead. Every step lands in NVS before the next begins, so
 // the table survives a brownout, a power cut, or a cell collapse.
-// guardVbatt: enforce the cell floor (true when actually running from a cell).
-static void unattendedSweep(bool guardVbatt) {
+// startedOnBattery: a 'B' sweep aborts if USB returns mid-run (its data mixes
+// sources otherwise). The cell-voltage floor is checked DYNAMICALLY — if a
+// brick folds mid-'U'-sweep and the mux hands off to the cell, the floor
+// guard picks up from that step (a V0.4 sweep can change sources mid-run).
+static void unattendedSweep(bool startedOnBattery) {
   memset(&g_log, 0, sizeof(g_log));
   g_log.unread = 1;
 
@@ -238,9 +246,10 @@ static void unattendedSweep(bool guardVbatt) {
     g_log.duty[i] = d; g_log.ma[i] = ma; g_log.vb[i] = vb;
     g_log.count = i + 1;
 
+    const bool onCellNow = PIN_BATT_ADC >= 0 && !onUsb();
     if      (ma > limitMa())                          g_log.abortReason = 1;
-    else if (guardVbatt && vb < USWEEP_MIN_VBATT)     g_log.abortReason = 2;
-    else if (guardVbatt && onUsb())                   g_log.abortReason = 3;
+    else if (onCellNow && vb < USWEEP_MIN_VBATT)      g_log.abortReason = 2;
+    else if (startedOnBattery && onUsb())             g_log.abortReason = 3;
     saveLog();                                   // step is safe in flash NOW
 
     ledcWrite(PIN_MIST_PWM, 0);                  // off-cooldown for L1
@@ -255,7 +264,7 @@ static void unattendedSweep(bool guardVbatt) {
 }
 
 static void printHelp() {
-  Serial.printf("[HELP] w=serial sweep  U=arm sweep-on-next-boot  L=limit (now %.0f mA)\n", limitMa());
+  Serial.printf("[HELP] w=serial sweep  U=arm unattended sweep  L=limit (now %.0f mA)\n", limitMa());
 #if defined(BOARD_BATTERY_KIT_V04)
   Serial.println("[HELP] B=arm battery sweep (unplug USB after arming)");
 #endif
@@ -300,7 +309,7 @@ void setup() {
     while (millis() - t0 < USWEEP_BOOT_DELAY_MS)
       if (Serial.available() && Serial.read() == 'x') { cancelled = true; break; }
     if (!cancelled) {
-      unattendedSweep(!onUsb());                 // guard the cell only if on it
+      unattendedSweep(!onUsb());                 // startedOnBattery if no USB now
       // On a wall brick nobody sees this print — the table stays flagged
       // unread in flash and replays when the board is back on the computer.
       printLogTable("[LOG] ==== unattended sweep results ====");
@@ -319,6 +328,18 @@ void setup() {
 }
 
 void loop() {
+  // 'U' armed while a cell keeps the board alive: no reboot will come, so
+  // trigger when USB drops (unplug from computer) and returns (wall brick).
+  if (g_armUPending && PIN_USB_SENSE >= 0) {
+    if (!onUsb()) g_sawUsbDrop = true;
+    else if (g_sawUsbDrop) {
+      g_armUPending = false; g_sawUsbDrop = false;
+      prefs.putUChar("armU", 0);
+      delay(USWEEP_BOOT_DELAY_MS);               // settle on the new supply
+      unattendedSweep(false);                    // started on USB (brick)
+    }
+  }
+
 #if defined(BOARD_BATTERY_KIT_V04)
   // Armed battery sweep: wait for the unplug, then run unattended.
   if (g_armedBatt) {
@@ -366,10 +387,12 @@ void loop() {
 #endif
     else if (ch == 'U') {
       prefs.putUChar("armU", 1);
-      Serial.printf("[U] ARMED for next boot (limit %.0f mA, duty 50->90%%).\n", limitMa());
-      Serial.println("[U] Unplug and move the board to your power source (wall charger");
-      Serial.println("[U] is ideal). It boots, waits 8 s, sweeps, and logs to flash.");
-      Serial.println("[U] Plug back into the computer afterwards to read the table.");
+      g_armUPending = true; g_sawUsbDrop = false;
+      Serial.printf("[U] ARMED (limit %.0f mA, duty 50->90%%).\n", limitMa());
+      Serial.println("[U] Unplug and move the board to the wall charger. No cell: it");
+      Serial.println("[U] boots there, waits 8 s, sweeps. Cell attached: it stays alive");
+      Serial.println("[U] and starts 8 s after USB power returns. Either way the table");
+      Serial.println("[U] logs to flash — plug back into the computer to read it.");
     }
     else if (ch == 'L') {
       g_limitIdx = (g_limitIdx + 1) % (sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0]));
@@ -382,7 +405,8 @@ void loop() {
         printLogTable("[LOG] ==== last sweep stored in flash ====");
       else Serial.println("[LOG] no sweep stored yet.");
     }
-    else if (ch == 'x') { g_armedBatt = false; prefs.putUChar("armU", 0); setDuty(0); }
+    else if (ch == 'x') { g_armedBatt = false; g_armUPending = false;
+                          g_sawUsbDrop = false; prefs.putUChar("armU", 0); setDuty(0); }
     else if (ch == 's') { g_stream = !g_stream;
                           Serial.printf("[CFG] stream %s\n", g_stream ? "ON" : "OFF"); }
     else if (ch == '+') setDuty(g_duty + 4 > DUTY_HARD_MAX ? DUTY_HARD_MAX : g_duty + 4);

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -12,6 +12,14 @@
 //   * If mist keeps clearly increasing past 60-70% duty, the cap is wrong
 //     for this board and we should raise the library default.
 //
+// BENCH RESULT (V0.4 board, 2026-07-03): mist kept INCREASING past 50% —
+// but current went superlinear (224 mA @50% -> 1.1 A @75%, ~5x power for
+// the gain: inductor saturation territory), and at ~75% total USB draw hit
+// ~1.5 A, VBUS sagged, and the board BROWNED OUT mid-sweep (the banner
+// reprinting = reboot; the TPS2116 drops USB when VBUS < 4.0 V). So 50%
+// is the efficiency/stability knee, not a mist maximum. The sweep now
+// aborts above SWEEP_ABORT_MA to fail gracefully instead of rebooting.
+//
 // Setup: Battery Kit V0.4 (or V0.3 — same D0/D2/D3), disc IN WATER (never
 // sweep a dry disc), USB serial @ 115200. Best in still air, good light.
 //
@@ -28,6 +36,7 @@
 // high duty for minutes. If anything smells hot, hit 'x'.
 
 #include <Arduino.h>
+#include <esp_system.h>   // esp_reset_reason(): names a brownout after the fact
 
 #if defined(ARDUINO_XIAO_ESP32C6) || defined(ARDUINO_XIAO_ESP32S3) || \
     defined(ARDUINO_XIAO_ESP32S3_PLUS) || defined(ARDUINO_XIAO_ESP32C3)
@@ -45,6 +54,12 @@ constexpr float    SENSE_V_PER_A = 3.0f;          // INA180A3 (100 V/V) x 30 mOh
 constexpr uint8_t  SWEEP_STEPS    = 16;           // 0..255 in 17 points
 constexpr uint16_t SWEEP_DWELL_MS = 3000;         // per step
 constexpr uint16_t SWEEP_SETTLE_MS = 1500;        // dwell before sampling starts
+// Abort the sweep above this drive current. Bench (2026-07-03): L1 (the 3-leg
+// autotransformer) is already hot to touch at ~485 mA / 62% duty, and ~1.1 A
+// / 75% duty sagged USB VBUS into a brownout reset. 600 mA keeps the sweep in
+// "informative but not self-destructive" territory; raise it deliberately if
+// you're on a beefy supply and watching L1's temperature.
+constexpr float SWEEP_ABORT_MA = 600.0f;
 
 static uint8_t  g_duty  = 0;
 static bool     g_stream = false;
@@ -74,6 +89,7 @@ static void sweep() {
 
   float ma[SWEEP_STEPS + 1];
   uint8_t duties[SWEEP_STEPS + 1];
+  uint8_t ran = 0;                                 // steps actually measured
 
   for (uint8_t i = 0; i <= SWEEP_STEPS; i++) {
     const uint8_t d = (uint8_t)((uint16_t)i * 255 / SWEEP_STEPS);
@@ -82,8 +98,16 @@ static void sweep() {
     ledcWrite(PIN_MIST_PWM, d);
     delay(SWEEP_SETTLE_MS);                        // let drive + water column respond
     ma[i] = readMa(SWEEP_DWELL_MS - SWEEP_SETTLE_MS);
+    ran = i + 1;
     Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA\n",
                   i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i]);
+    if (ma[i] > SWEEP_ABORT_MA) {
+      Serial.printf("[SWEEP] %.0f mA > %.0f mA limit — stopping here. Past this\n"
+                    "[SWEEP] point L1 saturates (runs hot) and USB VBUS sag can\n"
+                    "[SWEEP] brown-out the board. Raise SWEEP_ABORT_MA to explore.\n",
+                    ma[i], SWEEP_ABORT_MA);
+      break;
+    }
     if (Serial.available() && Serial.read() == 'x') { Serial.println("[SWEEP] aborted"); break; }
   }
   setDuty(0);
@@ -92,7 +116,7 @@ static void sweep() {
   // it) — so print the table for pairing with what you SAW.
   Serial.println();
   Serial.println("[RESULT] duty%, mA   (paste next to your mist notes)");
-  for (uint8_t i = 0; i <= SWEEP_STEPS; i++)
+  for (uint8_t i = 0; i < ran; i++)
     Serial.printf("%5.1f, %.1f\n", duties[i] * 100.0f / 255.0f, ma[i]);
   Serial.println();
   Serial.println("[RESULT] Reading it: if current rose monotonically but mist");
@@ -117,6 +141,13 @@ void setup() {
   Serial.println("==============================================");
   Serial.println(" Duty Sweep - does mist peak at 50% duty?");
   Serial.println("==============================================");
+  // If the previous run ended in a mid-sweep reboot, this line names it:
+  // "brownout" = the supply sagged under the high-duty load.
+  const esp_reset_reason_t rr = esp_reset_reason();
+  Serial.printf("[BOOT] reset: %s\n",
+                rr == ESP_RST_BROWNOUT ? "BROWNOUT (supply sagged under load!)"
+                : rr == ESP_RST_POWERON ? "power-on"
+                : rr == ESP_RST_SW      ? "software" : "other");
   Serial.println("[!] Disc must be IN WATER before you start.");
   printHelp();
 }

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -1,77 +1,93 @@
-// DutySweep_Test — how much mist can the V0.4 board actually make?
+// DutySweep_Test — how much mist can the board actually make?
 //
-// v1 asked "does mist peak at 50% duty?" — bench answer (2026-07-03): NO,
-// mist keeps rising past 50% on this flyback-style drive, but current goes
-// superlinear (224 mA @50% -> 1.1 A @75%), L1 runs hot by ~62%, and ~1.5 A
-// total USB draw at 75% sags VBUS into a brownout (TPS2116 drops USB below
-// 4.0 V). So the USB port, not the circuit, set the ceiling.
+// Works on the Battery Kit V0.4 AND the Seeed Extension Kit V0.1 (pick your
+// board below). Bench story so far (V0.4, 2026-07-03): mist keeps rising past
+// 50% duty on this flyback-style drive, but current goes superlinear
+// (224 mA @50% -> 1.1 A @75%), L1 runs hot by ~62%, a laptop USB port CUTS
+// POWER (~1.5 A, reset reason "power-on"), and a half-charged cell hits the
+// LDO-dropout floor at 60%. The circuit's own limits (D1's 1 A rating, the
+// 90% duty ceiling) haven't been reached yet — that's what this build is for.
 //
-// v2 adds the tools to push past that ceiling safely:
-//   * runtime current limit (`L` cycles 600 -> 900 -> 1200 mA). 1200 is the
-//     hard max: D1 (PMEG10010, series Schottky in the drive feed) is rated
-//     1 A continuous — brief steps above it are survivable, parking is not.
-//   * BATTERY SWEEP (`B`): the cell can source what USB can't. Arm it over
-//     serial, unplug USB, and the board runs the sweep unattended from the
-//     cell (duty 50 -> 90%), logging every step to flash (NVS) so even a
-//     brownout can't lose the data. Replug USB — the table replays.
-//     Guards: current > 1.2 A, loaded Vbatt < 3.5 V (the 3V3 LDO drops out
-//     ~3.65 V — abort before the XIAO browns out), USB replug mid-sweep.
-//   * duty hard-cap 230/255 (~90%) everywhere: at 108.7 kHz the period is
-//     9.2 us and the resonant ring-back needs ~4.6 us of off-time — above
-//     ~90% there is no ring, no mist, and L1 becomes a DC heater. 100% duty
-//     is a short circuit with extra steps, not "max mist".
+// Why the Extension Kit is a good max-test vehicle: same drive stage as V0.4
+// (L1 / FET / D1 / 30 mOhm shunt), but no charger stealing ~200 mA and no
+// TPS2116 whose 4.0 V threshold drops USB mid-sag — plus you can feed it from
+// a beefy 5 V wall charger. Note its INA180 runs from 3V3, so current reads
+// SATURATE ~1.05 A ("sat!" flag in the tables).
 //
-// Thermal protocol: L1 is hot to touch from ~485 mA. High-duty steps dwell
-// only ~1.5 s with an off-cooldown between; let the board rest a minute or
-// two between full runs, and touch-check L1. Disc IN WATER, always.
+// Three ways to run a sweep:
+//   w   attended, over serial (0 -> 90%, ~3 s/step, current-limit abort)
+//   B   battery sweep (V0.4 only): arm, unplug USB, board sweeps 50 -> 90%
+//       from the cell, logs to flash, replays the table when USB returns
+//   U   unattended sweep ON NEXT BOOT (any board, any supply): arm, move the
+//       board to a wall charger, it boots + waits 8 s + sweeps 50 -> 90%,
+//       logging to flash; plug back into the laptop and the table replays.
 //
-// Commands (serial 115200):
-//   w        USB sweep 0 -> 90% (~3 s/step, aborts at the current limit)
-//   B        arm the battery sweep, then unplug USB within 30 s
-//   L        cycle the current limit: 600 / 900 / 1200 mA
-//   0..9     hold duty at n*10% (capped at 90%)   + / -  nudge by 4
-//   s        CSV stream (duty, mA, Vbatt, USB) for the Serial Plotter
-//   x        everything off / disarm    h  help
+// Safety rails (all sweeps): current limit ('L': 600/900/1200 mA — 1200 is
+// D1's PMEG10010 1 A edge, short steps only), loaded Vbatt < 3.5 V abort on
+// the cell (3V3 LDO drops out ~3.65 V), duty hard-cap 230/255 (~90%): at
+// 108.7 kHz the period is 9.2 us and the ring-back needs ~4.6 us of off-time
+// — above ~90% there is no ring, no mist, and L1 is just a DC heater.
+// Thermal protocol: short high-duty dwells + off-cooldowns are built in, but
+// rest the board a minute between runs and touch-check L1. Disc IN WATER.
+//
+// Commands: w/B/U as above, L=limit, 0..9=hold duty (capped 90%), +/-=nudge,
+//           s=CSV stream, x=off/disarm, h=help.
 
 #include <Arduino.h>
-#include <esp_system.h>    // esp_reset_reason(): names a brownout after the fact
-#include <Preferences.h>   // NVS: battery-sweep black box, survives any reset
+#include <esp_system.h>    // esp_reset_reason(): names a brownout / power cut
+#include <Preferences.h>   // NVS black box: sweep logs survive any reset
 
-#if defined(ARDUINO_XIAO_ESP32C6) || defined(ARDUINO_XIAO_ESP32S3) || \
-    defined(ARDUINO_XIAO_ESP32S3_PLUS) || defined(ARDUINO_XIAO_ESP32C3)
-  constexpr uint8_t PIN_MIST_PWM    = D0;   // gate driver input
-  constexpr uint8_t PIN_BATT_ADC    = D1;   // battery via 10k/10k divider
-  constexpr uint8_t PIN_CURRENT_ADC = D2;   // INA180A3 out (3.0 V per A)
-  constexpr uint8_t PIN_BOOST_EN    = D3;   // TPS61023 EN (HIGH = 5V rail on)
-  constexpr uint8_t PIN_USB_SENSE   = D8;   // TPS2116 ST: HIGH = USB, LOW = cell
-#else
+// ---------------- board select (uncomment exactly ONE) ----------------
+#define BOARD_BATTERY_KIT_V04
+// #define BOARD_EXTENSION_KIT_V01
+
+#if !defined(ARDUINO_XIAO_ESP32C6) && !defined(ARDUINO_XIAO_ESP32S3) && \
+    !defined(ARDUINO_XIAO_ESP32S3_PLUS) && !defined(ARDUINO_XIAO_ESP32C3)
   #error "Select a XIAO ESP32 board in Tools > Board."
+#endif
+
+#if defined(BOARD_BATTERY_KIT_V04)
+  constexpr uint8_t PIN_MIST_PWM    = D0;
+  constexpr uint8_t PIN_BATT_ADC    = D1;    // cell via 10k/10k divider
+  constexpr uint8_t PIN_CURRENT_ADC = D2;    // INA180A3 (5 V rail -> ~1.55 A range)
+  constexpr int8_t  PIN_BOOST_EN    = D3;    // TPS61023 EN
+  constexpr int8_t  PIN_USB_SENSE   = D8;    // TPS2116 ST: HIGH = USB
+  constexpr float   SENSE_SAT_MA    = 1550.0f;
+#elif defined(BOARD_EXTENSION_KIT_V01)
+  constexpr uint8_t PIN_MIST_PWM    = D0;
+  constexpr int8_t  PIN_BATT_ADC    = -1;    // no cell
+  constexpr uint8_t PIN_CURRENT_ADC = D2;    // INA180A3 (3V3 rail -> saturates ~1.05 A)
+  constexpr int8_t  PIN_BOOST_EN    = -1;    // piezo rail = VBUS, always on
+  constexpr int8_t  PIN_USB_SENSE   = -1;    // no mux
+  constexpr float   SENSE_SAT_MA    = 1000.0f;
+#else
+  #error "Uncomment one BOARD_* define above."
 #endif
 
 constexpr uint32_t MIST_FREQ_HZ  = 108700;
 constexpr uint8_t  PWM_RES_BITS  = 8;
 constexpr float    SENSE_V_PER_A = 3.0f;    // INA180A3 (100 V/V) x 30 mOhm
-constexpr float    BATT_DIVIDER  = 2.0f;    // 10k/10k
+constexpr float    BATT_DIVIDER  = 2.0f;
 
-// ~90% of 255. Above this the off-window can't fit the resonant ring-back:
-// no mist, just DC heating in L1. Applies to sweeps AND manual duty.
+// ~90% of 255 — above this the off-window can't fit the resonant ring-back.
 constexpr uint8_t DUTY_HARD_MAX = 230;
 
-// USB sweep (attended, ~3 s/step)
+// Attended USB sweep
 constexpr uint8_t  SWEEP_STEPS     = 16;
 constexpr uint16_t SWEEP_DWELL_MS  = 3000;
 constexpr uint16_t SWEEP_SETTLE_MS = 1500;
 
-// Battery sweep (unattended): duty 127 -> 230 in 13-count steps, short dwell
+// Unattended sweeps (battery 'B' / on-boot 'U'): 50 -> 90% duty, short dwell
 // + off-cooldown to keep L1 survivable at the currents involved.
-constexpr uint8_t  BSWEEP_START    = 127;
-constexpr uint8_t  BSWEEP_STEP     = 13;
-constexpr uint16_t BSWEEP_SETTLE_MS   = 500;
-constexpr uint16_t BSWEEP_SAMPLE_MS   = 1000;
-constexpr uint16_t BSWEEP_COOLDOWN_MS = 1000;
+constexpr uint8_t  USWEEP_START    = 127;
+constexpr uint8_t  USWEEP_STEP     = 13;
+constexpr uint16_t USWEEP_SETTLE_MS   = 500;
+constexpr uint16_t USWEEP_SAMPLE_MS   = 1000;
+constexpr uint16_t USWEEP_COOLDOWN_MS = 1000;
 constexpr uint32_t BSWEEP_ARM_TIMEOUT_MS = 30000;
-constexpr float    BSWEEP_MIN_VBATT = 3.50f;  // loaded; LDO dropout ~3.65 V
-constexpr uint8_t  BSWEEP_MAX_STEPS = 10;
+constexpr uint32_t USWEEP_BOOT_DELAY_MS  = 8000;
+constexpr float    USWEEP_MIN_VBATT = 3.50f;  // loaded; LDO dropout ~3.65 V
+constexpr uint8_t  USWEEP_MAX_STEPS = 10;
 
 constexpr float LIMIT_STEPS_MA[] = { 600.0f, 900.0f, 1200.0f };  // 1200 = D1's edge
 
@@ -79,23 +95,28 @@ static uint8_t  g_duty = 0;
 static bool     g_stream = false;
 static uint32_t g_lastStreamMs = 0;
 static uint8_t  g_limitIdx = 0;
-static bool     g_armed = false;
+static bool     g_armedBatt = false;
 static uint32_t g_armedAtMs = 0;
 Preferences prefs;
 
-struct BsweepLog {                 // black box, one NVS blob
-  uint8_t  count;                  // steps recorded
-  uint8_t  done;                   // 1 = sweep finished cleanly
+struct SweepLog {                  // black box, one NVS blob
+  uint8_t  count;
+  uint8_t  done;                   // 1 = finished cleanly
   uint8_t  unread;                 // 1 = not yet replayed over serial
   uint8_t  abortReason;            // 0 ok, 1 overcurrent, 2 vbatt, 3 usb-replug
-  uint8_t  duty[BSWEEP_MAX_STEPS];
-  float    ma[BSWEEP_MAX_STEPS];
-  float    vb[BSWEEP_MAX_STEPS];
+  uint8_t  duty[USWEEP_MAX_STEPS];
+  float    ma[USWEEP_MAX_STEPS];
+  float    vb[USWEEP_MAX_STEPS];
 };
-static BsweepLog g_log;
+static SweepLog g_log;
 
 static float limitMa() { return LIMIT_STEPS_MA[g_limitIdx]; }
-static bool  onUsb()   { return digitalRead(PIN_USB_SENSE) == HIGH; }
+static bool  onUsb() {                       // no mux ST pin -> assume USB
+  return PIN_USB_SENSE < 0 || digitalRead((uint8_t)PIN_USB_SENSE) == HIGH;
+}
+static void boostEn(bool on) {
+  if (PIN_BOOST_EN >= 0) digitalWrite((uint8_t)PIN_BOOST_EN, on ? HIGH : LOW);
+}
 
 static float readMa(uint16_t sampleMs) {
   uint32_t sum_mV = 0, n = 0;
@@ -103,10 +124,13 @@ static float readMa(uint16_t sampleMs) {
   while (millis() - t0 < sampleMs) { sum_mV += analogReadMilliVolts(PIN_CURRENT_ADC); n++; }
   return n ? (float(sum_mV) / n) / SENSE_V_PER_A : 0.0f;   // mV / (V/A) = mA
 }
+// "sat!" = at/above the sense amp's output ceiling — real current is HIGHER.
+static const char* satFlag(float ma) { return ma >= SENSE_SAT_MA * 0.97f ? " sat!" : ""; }
 
 static float readVbatt() {
+  if (PIN_BATT_ADC < 0) return 0.0f;
   uint32_t sum_mV = 0;
-  for (uint8_t i = 0; i < 16; i++) sum_mV += analogReadMilliVolts(PIN_BATT_ADC);
+  for (uint8_t i = 0; i < 16; i++) sum_mV += analogReadMilliVolts((uint8_t)PIN_BATT_ADC);
   return (float(sum_mV) / 16.0f) / 1000.0f * BATT_DIVIDER;
 }
 
@@ -118,7 +142,7 @@ static void setDuty(uint8_t d) {
     d = DUTY_HARD_MAX;
   }
   g_duty = d;
-  digitalWrite(PIN_BOOST_EN, d > 0 ? HIGH : LOW);
+  boostEn(d > 0);
   if (d > 0) delayMicroseconds(500);
   ledcWrite(PIN_MIST_PWM, d);
   Serial.printf("[DUTY] %3u/255 = %5.1f%%\n", d, d * 100.0f / 255.0f);
@@ -126,22 +150,23 @@ static void setDuty(uint8_t d) {
 
 static void saveLog() { prefs.putBytes("blog", &g_log, sizeof(g_log)); }
 
-static void printBsweepTable(const char* header) {
+static void printLogTable(const char* header) {
   Serial.println();
   Serial.println(header);
-  Serial.println("[BATT]  duty%   drive-mA   Vbatt");
+  Serial.println("[LOG]  duty%   drive-mA   Vbatt");
   for (uint8_t i = 0; i < g_log.count; i++)
-    Serial.printf("[BATT]  %5.1f   %7.1f   %5.2f V\n",
-                  g_log.duty[i] * 100.0f / 255.0f, g_log.ma[i], g_log.vb[i]);
+    Serial.printf("[LOG]  %5.1f   %7.1f%s   %5.2f V\n",
+                  g_log.duty[i] * 100.0f / 255.0f, g_log.ma[i],
+                  satFlag(g_log.ma[i]), g_log.vb[i]);
   const char* why = g_log.abortReason == 1 ? "current limit (D1 rating)"
                   : g_log.abortReason == 2 ? "cell sagged (LDO dropout guard)"
                   : g_log.abortReason == 3 ? "USB replugged mid-sweep"
                   : g_log.done             ? "completed full range"
                                            : "DID NOT FINISH (reset mid-sweep?)";
-  Serial.printf("[BATT] end: %s\n", why);
+  Serial.printf("[LOG] end: %s\n", why);
 }
 
-// ---------------- USB (attended) sweep ----------------
+// ---------------- attended (serial) sweep ----------------
 static void sweep() {
   Serial.println();
   Serial.printf("[SWEEP] 0 -> 90%% duty, limit %.0f mA ('L' raises it). WATCH THE MIST.\n", limitMa());
@@ -155,17 +180,17 @@ static void sweep() {
     uint8_t d = (uint8_t)((uint16_t)i * 255 / SWEEP_STEPS);
     if (d > DUTY_HARD_MAX) d = DUTY_HARD_MAX;
     duties[i] = d;
-    digitalWrite(PIN_BOOST_EN, HIGH);
+    boostEn(true);
     ledcWrite(PIN_MIST_PWM, d);
     delay(SWEEP_SETTLE_MS);
     ma[i] = readMa(SWEEP_DWELL_MS - SWEEP_SETTLE_MS);
     ran = i + 1;
-    Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA\n",
-                  i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i]);
+    Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA%s\n",
+                  i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i], satFlag(ma[i]));
     if (ma[i] > limitMa()) {
       Serial.printf("[SWEEP] %.0f mA > %.0f mA limit — stopping. 'L' raises the limit\n"
-                    "[SWEEP] (max 1200 mA = D1's rating); 'B' sweeps from the battery\n"
-                    "[SWEEP] instead, which dodges the USB brownout entirely.\n",
+                    "[SWEEP] (max 1200 mA = D1's rating). 'U' arms an unattended sweep\n"
+                    "[SWEEP] you can run from a beefy wall charger.\n",
                     ma[i], limitMa());
       break;
     }
@@ -177,18 +202,19 @@ static void sweep() {
   Serial.println();
   Serial.println("[RESULT] duty%, mA   (paste next to your mist notes)");
   for (uint8_t i = 0; i < ran; i++)
-    Serial.printf("%5.1f, %.1f\n", duties[i] * 100.0f / 255.0f, ma[i]);
+    Serial.printf("%5.1f, %.1f%s\n", duties[i] * 100.0f / 255.0f, ma[i], satFlag(ma[i]));
 }
 
-// ---------------- battery (unattended) sweep ----------------
+// ---------------- unattended sweep (battery 'B' / on-boot 'U') ----------------
 // Runs with serial dead. Every step lands in NVS before the next begins, so
-// the table survives a brownout, a cell collapse, or a mid-sweep reset.
-static void batterySweep() {
+// the table survives a brownout, a power cut, or a cell collapse.
+// guardVbatt: enforce the cell floor (true when actually running from a cell).
+static void unattendedSweep(bool guardVbatt) {
   memset(&g_log, 0, sizeof(g_log));
   g_log.unread = 1;
 
-  // Row 0: duty-0 baseline — resting-ish cell voltage. The sag from this row
-  // to the loaded rows is the cell's internal-resistance story.
+  // Row 0: duty-0 baseline (resting-ish Vbatt; the sag in later rows vs this
+  // row is the cell's internal-resistance story).
   delay(300);
   g_log.duty[0] = 0;
   g_log.ma[0]   = readMa(200);
@@ -196,60 +222,63 @@ static void batterySweep() {
   g_log.count   = 1;
   saveLog();
 
-  for (uint8_t i = 1; i < BSWEEP_MAX_STEPS; i++) {
-    uint16_t d16 = BSWEEP_START + (uint16_t)(i - 1) * BSWEEP_STEP;
+  for (uint8_t i = 1; i < USWEEP_MAX_STEPS; i++) {
+    uint16_t d16 = USWEEP_START + (uint16_t)(i - 1) * USWEEP_STEP;
     const uint8_t d = d16 > DUTY_HARD_MAX ? DUTY_HARD_MAX : (uint8_t)d16;
 
-    digitalWrite(PIN_BOOST_EN, HIGH);
+    boostEn(true);
     ledcWrite(PIN_MIST_PWM, d);
-    delay(BSWEEP_SETTLE_MS);
-    const float ma = readMa(BSWEEP_SAMPLE_MS);
+    delay(USWEEP_SETTLE_MS);
+    const float ma = readMa(USWEEP_SAMPLE_MS);
     const float vb = readVbatt();               // still under load
 
     g_log.duty[i] = d; g_log.ma[i] = ma; g_log.vb[i] = vb;
     g_log.count = i + 1;
 
-    if      (ma > limitMa())          g_log.abortReason = 1;
-    else if (vb < BSWEEP_MIN_VBATT)   g_log.abortReason = 2;
-    else if (onUsb())                 g_log.abortReason = 3;
+    if      (ma > limitMa())                          g_log.abortReason = 1;
+    else if (guardVbatt && vb < USWEEP_MIN_VBATT)     g_log.abortReason = 2;
+    else if (guardVbatt && onUsb())                   g_log.abortReason = 3;
     saveLog();                                   // step is safe in flash NOW
 
     ledcWrite(PIN_MIST_PWM, 0);                  // off-cooldown for L1
-    delay(BSWEEP_COOLDOWN_MS);
+    delay(USWEEP_COOLDOWN_MS);
 
     if (g_log.abortReason || d == DUTY_HARD_MAX) break;
   }
   g_log.done = 1;
   saveLog();
   ledcWrite(PIN_MIST_PWM, 0);
-  digitalWrite(PIN_BOOST_EN, LOW);
+  boostEn(false);
 }
 
 static void printHelp() {
-  Serial.printf("[HELP] w=USB sweep  B=arm battery sweep  L=limit (now %.0f mA)\n", limitMa());
+  Serial.printf("[HELP] w=serial sweep  U=arm sweep-on-next-boot  L=limit (now %.0f mA)\n", limitMa());
+#if defined(BOARD_BATTERY_KIT_V04)
+  Serial.println("[HELP] B=arm battery sweep (unplug USB after arming)");
+#endif
   Serial.println("[HELP] 0..9=duty n*10%  +/-=nudge  s=stream  x=off  h=help");
-  Serial.println("[HELP] battery sweep: press B, unplug USB, watch mist, replug, read table");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
   pinMode(PIN_CURRENT_ADC, INPUT);
-  pinMode(PIN_BATT_ADC, INPUT);
-  pinMode(PIN_USB_SENSE, INPUT);     // external divider — no internal pull!
-  pinMode(PIN_BOOST_EN, OUTPUT);
-  digitalWrite(PIN_BOOST_EN, LOW);
+  if (PIN_BATT_ADC  >= 0) pinMode((uint8_t)PIN_BATT_ADC, INPUT);
+  if (PIN_USB_SENSE >= 0) pinMode((uint8_t)PIN_USB_SENSE, INPUT); // external divider — no pull!
+  if (PIN_BOOST_EN  >= 0) { pinMode((uint8_t)PIN_BOOST_EN, OUTPUT); boostEn(false); }
   ledcAttach(PIN_MIST_PWM, MIST_FREQ_HZ, PWM_RES_BITS);
   ledcWrite(PIN_MIST_PWM, 0);
 
   prefs.begin("dsweep");
-  // The current limit survives reboots — a USB-overcurrent power cycle was
-  // silently resetting it to 600 mA between an 'L L' and the next sweep.
   g_limitIdx = prefs.getUChar("lim", 0);
   if (g_limitIdx >= sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0])) g_limitIdx = 0;
 
   Serial.println("==============================================");
-  Serial.println(" Duty Sweep v2 - find the V0.4 board's max");
+#if defined(BOARD_BATTERY_KIT_V04)
+  Serial.println(" Duty Sweep v3 - Battery Kit V0.4");
+#else
+  Serial.println(" Duty Sweep v3 - Extension Kit V0.1");
+#endif
   Serial.println("==============================================");
   const esp_reset_reason_t rr = esp_reset_reason();
   Serial.printf("[BOOT] reset: %s\n",
@@ -257,11 +286,30 @@ void setup() {
                 : rr == ESP_RST_POWERON ? "power-on"
                 : rr == ESP_RST_SW      ? "software" : "other");
 
-  // Black box from a previous battery sweep? Replay it.
+  // Armed for a sweep-on-boot ('U')? Run it now — even with no serial there.
+  if (prefs.getUChar("armU", 0)) {
+    prefs.putUChar("armU", 0);                   // one shot, even if we crash
+    Serial.printf("[U] armed sweep: starting in %lu s (x to cancel)...\n",
+                  (unsigned long)(USWEEP_BOOT_DELAY_MS / 1000));
+    const uint32_t t0 = millis();
+    bool cancelled = false;
+    while (millis() - t0 < USWEEP_BOOT_DELAY_MS)
+      if (Serial.available() && Serial.read() == 'x') { cancelled = true; break; }
+    if (!cancelled) {
+      unattendedSweep(!onUsb());                 // guard the cell only if on it
+      // On a wall brick nobody sees this print — the table stays flagged
+      // unread in flash and replays when the board is back on the computer.
+      printLogTable("[LOG] ==== unattended sweep results ====");
+    } else Serial.println("[U] cancelled.");
+  }
+
+  // Black box from a previous unattended sweep? Replay it.
   if (prefs.getBytes("blog", &g_log, sizeof(g_log)) == sizeof(g_log) && g_log.unread && g_log.count) {
-    printBsweepTable("[BATT] ==== battery sweep results (from flash) ====");
+    printLogTable("[LOG] ==== sweep results (from flash) ====");
     if (!g_log.done && rr == ESP_RST_BROWNOUT)
-      Serial.println("[BATT] the sweep itself browned the board out — that step is the wall.");
+      Serial.println("[LOG] the sweep itself browned the board out — that step is the wall.");
+    if (!g_log.done && rr == ESP_RST_POWERON)
+      Serial.println("[LOG] power was CUT mid-sweep (USB port breaker?) — that step is the wall.");
     g_log.unread = 0;
     saveLog();
   }
@@ -271,24 +319,26 @@ void setup() {
 }
 
 void loop() {
+#if defined(BOARD_BATTERY_KIT_V04)
   // Armed battery sweep: wait for the unplug, then run unattended.
-  if (g_armed) {
+  if (g_armedBatt) {
     if (!onUsb()) {
-      delay(2000);                               // let the unplug settle
-      batterySweep();
-      g_armed = false;                           // done; table prints on replug/reboot
+      delay(2000);
+      unattendedSweep(true);
+      g_armedBatt = false;                       // table replays on replug
     } else if (millis() - g_armedAtMs > BSWEEP_ARM_TIMEOUT_MS) {
-      g_armed = false;
+      g_armedBatt = false;
       Serial.println("[BATT] arm timed out (30 s) — press B and unplug sooner.");
     }
   }
+#endif
 
   // Replay results the moment serial + USB are back and a table is unread.
   static uint32_t lastReplayCheck = 0;
   if (onUsb() && millis() - lastReplayCheck > 1000) {
     lastReplayCheck = millis();
     if (g_log.unread && g_log.count && g_log.done) {
-      printBsweepTable("[BATT] ==== battery sweep results ====");
+      printLogTable("[LOG] ==== sweep results ====");
       g_log.unread = 0;
       saveLog();
     }
@@ -297,23 +347,32 @@ void loop() {
   while (Serial.available()) {
     const char ch = Serial.read();
     if      (ch == 'w') sweep();
+#if defined(BOARD_BATTERY_KIT_V04)
     else if (ch == 'B') {
       if (!onUsb()) { Serial.println("[BATT] already on battery — plug USB in, then arm."); }
       else {
-        g_armed = true; g_armedAtMs = millis();
+        g_armedBatt = true; g_armedAtMs = millis();
         Serial.printf("[BATT] ARMED (limit %.0f mA, floor %.2f V, duty 50->90%%).\n",
-                      limitMa(), BSWEEP_MIN_VBATT);
-        Serial.println("[BATT] Unplug USB within 30 s. Watch the mist per step (~2.5 s each).");
+                      limitMa(), USWEEP_MIN_VBATT);
+        Serial.println("[BATT] Unplug USB within 30 s. Watch the mist (~2.5 s/step).");
         Serial.println("[BATT] Replug when the mist stops — the table replays here.");
       }
     }
+#endif
+    else if (ch == 'U') {
+      prefs.putUChar("armU", 1);
+      Serial.printf("[U] ARMED for next boot (limit %.0f mA, duty 50->90%%).\n", limitMa());
+      Serial.println("[U] Unplug and move the board to your power source (wall charger");
+      Serial.println("[U] is ideal). It boots, waits 8 s, sweeps, and logs to flash.");
+      Serial.println("[U] Plug back into the computer afterwards to read the table.");
+    }
     else if (ch == 'L') {
       g_limitIdx = (g_limitIdx + 1) % (sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0]));
-      prefs.putUChar("lim", g_limitIdx);           // survives reboot/power-cycle
+      prefs.putUChar("lim", g_limitIdx);         // survives reboot/power-cycle
       Serial.printf("[CFG] current limit -> %.0f mA%s\n", limitMa(),
                     g_limitIdx == 2 ? "  (D1's 1 A rating — short steps only, watch L1!)" : "");
     }
-    else if (ch == 'x') { g_armed = false; setDuty(0); }
+    else if (ch == 'x') { g_armedBatt = false; prefs.putUChar("armU", 0); setDuty(0); }
     else if (ch == 's') { g_stream = !g_stream;
                           Serial.printf("[CFG] stream %s\n", g_stream ? "ON" : "OFF"); }
     else if (ch == '+') setDuty(g_duty + 4 > DUTY_HARD_MAX ? DUTY_HARD_MAX : g_duty + 4);

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -46,6 +46,10 @@
   #error "Select a XIAO ESP32 board in Tools > Board."
 #endif
 
+#if defined(BOARD_BATTERY_KIT_V04) && defined(BOARD_EXTENSION_KIT_V01)
+  #error "Define exactly ONE board above (comment the other out)."
+#endif
+
 #if defined(BOARD_BATTERY_KIT_V04)
   constexpr uint8_t PIN_MIST_PWM    = D0;
   constexpr uint8_t PIN_BATT_ADC    = D1;    // cell via 10k/10k divider
@@ -104,16 +108,34 @@ static bool     g_armUPending = false;
 static bool     g_sawUsbDrop  = false;
 Preferences prefs;
 
+constexpr uint32_t SWEEP_LOG_MAGIC = 0x4D535732;  // 'MSW2' — bump on layout change
+
 struct SweepLog {                  // black box, one NVS blob
+  uint32_t magic;                  // SWEEP_LOG_MAGIC, guards stale/foreign blobs
   uint8_t  count;
-  uint8_t  done;                   // 1 = finished cleanly
+  uint8_t  done;                   // 1 = terminal state saved (completed OR controlled abort)
   uint8_t  unread;                 // 1 = not yet replayed over serial
-  uint8_t  abortReason;            // 0 ok, 1 overcurrent, 2 vbatt, 3 usb-replug
+  uint8_t  abortReason;            // 0 ok, 1 overcurrent, 2 vbatt, 3 usb-replug, 4 sensor-saturated
   uint8_t  duty[USWEEP_MAX_STEPS];
   float    ma[USWEEP_MAX_STEPS];
   float    vb[USWEEP_MAX_STEPS];
 };
 static SweepLog g_log;
+
+// Load the stored blob only if it is exactly our layout and sane — a blob from
+// an older sketch version must not partially populate g_log (count drives
+// array reads in printLogTable).
+static bool loadLog() {
+  SweepLog tmp;
+  if (prefs.getBytes("blog", &tmp, sizeof(tmp)) == sizeof(tmp) &&
+      tmp.magic == SWEEP_LOG_MAGIC && tmp.count <= USWEEP_MAX_STEPS) {
+    g_log = tmp;
+    return true;
+  }
+  memset(&g_log, 0, sizeof(g_log));
+  g_log.magic = SWEEP_LOG_MAGIC;
+  return false;
+}
 
 static float limitMa() { return LIMIT_STEPS_MA[g_limitIdx]; }
 static bool  onUsb() {                       // no mux ST pin -> assume USB
@@ -169,6 +191,7 @@ static void printLogTable(const char* header) {
   const char* why = g_log.abortReason == 1 ? "current limit (D1 rating)"
                   : g_log.abortReason == 2 ? "cell sagged (LDO dropout guard)"
                   : g_log.abortReason == 3 ? "USB replugged mid-sweep"
+                  : g_log.abortReason == 4 ? "sensor saturated (current unmeasurable = uncontrollable)"
                   : g_log.done             ? "completed full range"
                                            : "DID NOT FINISH (reset mid-sweep?)";
   Serial.printf("[LOG] end: %s\n", why);
@@ -195,6 +218,11 @@ static void sweep() {
     ran = i + 1;
     Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA%s\n",
                   i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i], satFlag(ma[i]));
+    if (ma[i] >= SENSE_SAT_MA) {
+      Serial.println("[SWEEP] current sensor SATURATED — real current is higher than");
+      Serial.println("[SWEEP] the board can measure or limit. Stopping for safety.");
+      break;
+    }
     if (ma[i] > limitMa()) {
       Serial.printf("[SWEEP] %.0f mA > %.0f mA limit — stopping. 'L' raises the limit\n"
                     "[SWEEP] (max 1200 mA = D1's rating). 'U' arms an unattended sweep\n"
@@ -222,6 +250,7 @@ static void sweep() {
 // guard picks up from that step (a V0.4 sweep can change sources mid-run).
 static void unattendedSweep(bool startedOnBattery) {
   memset(&g_log, 0, sizeof(g_log));
+  g_log.magic  = SWEEP_LOG_MAGIC;
   g_log.unread = 1;
 
   // Row 0: duty-0 baseline (resting-ish Vbatt; the sag in later rows vs this
@@ -247,7 +276,8 @@ static void unattendedSweep(bool startedOnBattery) {
     g_log.count = i + 1;
 
     const bool onCellNow = PIN_BATT_ADC >= 0 && !onUsb();
-    if      (ma > limitMa())                          g_log.abortReason = 1;
+    if      (ma >= SENSE_SAT_MA)                      g_log.abortReason = 4;
+    else if (ma > limitMa())                          g_log.abortReason = 1;
     else if (onCellNow && vb < USWEEP_MIN_VBATT)      g_log.abortReason = 2;
     else if (startedOnBattery && onUsb())             g_log.abortReason = 3;
     saveLog();                                   // step is safe in flash NOW
@@ -300,7 +330,14 @@ void setup() {
                 : rr == ESP_RST_SW      ? "software" : "other");
 
   // Armed for a sweep-on-boot ('U')? Run it now — even with no serial there.
-  if (prefs.getUChar("armU", 0)) {
+  // Exception: booting on BATTERY (a reset mid-transfer) is not the intended
+  // supply — convert to "wait for USB to arrive" instead of sweeping a
+  // surprise source.
+  if (prefs.getUChar("armU", 0) && !onUsb()) {
+    prefs.putUChar("armU", 0);
+    g_armUPending = true; g_sawUsbDrop = true;   // sweep when USB (brick) shows up
+    Serial.println("[U] armed, booted on battery — will sweep when USB power arrives.");
+  } else if (prefs.getUChar("armU", 0)) {
     prefs.putUChar("armU", 0);                   // one shot, even if we crash
     Serial.printf("[U] armed sweep: starting in %lu s (x to cancel)...\n",
                   (unsigned long)(USWEEP_BOOT_DELAY_MS / 1000));
@@ -364,7 +401,7 @@ void loop() {
       printLogTable("[LOG] ==== sweep results ====");
       if (!g_log.done)
         Serial.println("[LOG] sweep did not finish — power was lost or the board "
-                       "reset mid-sweep; the last row is the wall.");
+                       "reset mid-sweep; the wall is at or just past the last saved row.");
       g_log.unread = 0;
       saveLog();
     }
@@ -377,6 +414,7 @@ void loop() {
     else if (ch == 'B') {
       if (!onUsb()) { Serial.println("[BATT] already on battery — plug USB in, then arm."); }
       else {
+        g_armUPending = false; g_sawUsbDrop = false; prefs.putUChar("armU", 0);
         g_armedBatt = true; g_armedAtMs = millis();
         Serial.printf("[BATT] ARMED (limit %.0f mA, floor %.2f V, duty 50->90%%).\n",
                       limitMa(), USWEEP_MIN_VBATT);
@@ -386,6 +424,7 @@ void loop() {
     }
 #endif
     else if (ch == 'U') {
+      g_armedBatt = false;                       // one arm mode at a time
       prefs.putUChar("armU", 1);
       g_armUPending = true; g_sawUsbDrop = false;
       Serial.printf("[U] ARMED (limit %.0f mA, duty 50->90%%).\n", limitMa());
@@ -401,9 +440,9 @@ void loop() {
                     g_limitIdx == 2 ? "  (D1's 1 A rating — short steps only, watch L1!)" : "");
     }
     else if (ch == 'r') {                        // reprint stored table, any state
-      if (prefs.getBytes("blog", &g_log, sizeof(g_log)) == sizeof(g_log) && g_log.count)
+      if (loadLog() && g_log.count)
         printLogTable("[LOG] ==== last sweep stored in flash ====");
-      else Serial.println("[LOG] no sweep stored yet.");
+      else Serial.println("[LOG] no sweep stored yet (or stored by an older sketch version).");
     }
     else if (ch == 'x') { g_armedBatt = false; g_armUPending = false;
                           g_sawUsbDrop = false; prefs.putUChar("armU", 0); setDuty(0); }

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -186,10 +186,18 @@ static void sweep() {
 static void batterySweep() {
   memset(&g_log, 0, sizeof(g_log));
   g_log.unread = 1;
+
+  // Row 0: duty-0 baseline — resting-ish cell voltage. The sag from this row
+  // to the loaded rows is the cell's internal-resistance story.
+  delay(300);
+  g_log.duty[0] = 0;
+  g_log.ma[0]   = readMa(200);
+  g_log.vb[0]   = readVbatt();
+  g_log.count   = 1;
   saveLog();
 
-  for (uint8_t i = 0; i < BSWEEP_MAX_STEPS; i++) {
-    uint16_t d16 = BSWEEP_START + (uint16_t)i * BSWEEP_STEP;
+  for (uint8_t i = 1; i < BSWEEP_MAX_STEPS; i++) {
+    uint16_t d16 = BSWEEP_START + (uint16_t)(i - 1) * BSWEEP_STEP;
     const uint8_t d = d16 > DUTY_HARD_MAX ? DUTY_HARD_MAX : (uint8_t)d16;
 
     digitalWrite(PIN_BOOST_EN, HIGH);
@@ -235,6 +243,10 @@ void setup() {
   ledcWrite(PIN_MIST_PWM, 0);
 
   prefs.begin("dsweep");
+  // The current limit survives reboots — a USB-overcurrent power cycle was
+  // silently resetting it to 600 mA between an 'L L' and the next sweep.
+  g_limitIdx = prefs.getUChar("lim", 0);
+  if (g_limitIdx >= sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0])) g_limitIdx = 0;
 
   Serial.println("==============================================");
   Serial.println(" Duty Sweep v2 - find the V0.4 board's max");
@@ -297,6 +309,7 @@ void loop() {
     }
     else if (ch == 'L') {
       g_limitIdx = (g_limitIdx + 1) % (sizeof(LIMIT_STEPS_MA) / sizeof(LIMIT_STEPS_MA[0]));
+      prefs.putUChar("lim", g_limitIdx);           // survives reboot/power-cycle
       Serial.printf("[CFG] current limit -> %.0f mA%s\n", limitMa(),
                     g_limitIdx == 2 ? "  (D1's 1 A rating — short steps only, watch L1!)" : "");
     }

--- a/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
+++ b/variants/battery-kit/firmware/DutySweep_Test/DutySweep_Test.ino
@@ -1,0 +1,141 @@
+// DutySweep_Test — does mist output really peak at ~50% PWM duty?
+//
+// The MistMaker library caps duty at 127/255 (50%) on the theory that a
+// single-transistor resonant drive makes the most mist there and only makes
+// more HEAT beyond it. This sketch bypasses the library and sweeps the raw
+// LEDC duty 0 -> 100% so you can verify that on real hardware.
+//
+// What to watch (your eyes are the mist sensor, the board logs the rest):
+//   * If the 50% theory holds: visible mist rises up to ~duty 120-140, then
+//     FLATTENS or DROPS — while input current KEEPS RISING. Current up +
+//     mist down = the extra duty is turning into transistor/tank heat.
+//   * If mist keeps clearly increasing past 60-70% duty, the cap is wrong
+//     for this board and we should raise the library default.
+//
+// Setup: Battery Kit V0.4 (or V0.3 — same D0/D2/D3), disc IN WATER (never
+// sweep a dry disc), USB serial @ 115200. Best in still air, good light.
+//
+// Commands:
+//   w        run the automatic sweep (0 -> 100% in 16 steps, ~3 s each,
+//            current logged per step, summary table at the end)
+//   0..9     hold duty at n*10% (e.g. 5 = 50%) for manual A/B comparison
+//   + / -    nudge duty by 4 counts
+//   s        toggle CSV stream (duty + mA) for the Serial Plotter
+//   x        everything off
+//
+// Safety: steps above ~60% run the FET/boost hotter than the design point —
+// the sweep dwells only 3 s per step and shuts off when done. Don't park at
+// high duty for minutes. If anything smells hot, hit 'x'.
+
+#include <Arduino.h>
+
+#if defined(ARDUINO_XIAO_ESP32C6) || defined(ARDUINO_XIAO_ESP32S3) || \
+    defined(ARDUINO_XIAO_ESP32S3_PLUS) || defined(ARDUINO_XIAO_ESP32C3)
+  constexpr uint8_t PIN_MIST_PWM    = D0;   // gate driver input
+  constexpr uint8_t PIN_CURRENT_ADC = D2;   // INA180A3 out (3.0 V per A)
+  constexpr uint8_t PIN_BOOST_EN    = D3;   // TPS61023 EN (HIGH = 5V rail on)
+#else
+  #error "Select a XIAO ESP32 board in Tools > Board."
+#endif
+
+constexpr uint32_t MIST_FREQ_HZ = 108700;
+constexpr uint8_t  PWM_RES_BITS = 8;              // duty 0..255
+constexpr float    SENSE_V_PER_A = 3.0f;          // INA180A3 (100 V/V) x 30 mOhm
+
+constexpr uint8_t  SWEEP_STEPS    = 16;           // 0..255 in 17 points
+constexpr uint16_t SWEEP_DWELL_MS = 3000;         // per step
+constexpr uint16_t SWEEP_SETTLE_MS = 1500;        // dwell before sampling starts
+
+static uint8_t  g_duty  = 0;
+static bool     g_stream = false;
+static uint32_t g_lastStreamMs = 0;
+
+// mA from the INA180. analogReadMilliVolts = factory-calibrated, linear on C6.
+static float readMa(uint16_t sampleMs) {
+  uint32_t sum_mV = 0, n = 0;
+  const uint32_t t0 = millis();
+  while (millis() - t0 < sampleMs) { sum_mV += analogReadMilliVolts(PIN_CURRENT_ADC); n++; }
+  return n ? (float(sum_mV) / n) / SENSE_V_PER_A : 0.0f;   // mV / (V/A) = mA
+}
+
+static void setDuty(uint8_t d) {
+  g_duty = d;
+  digitalWrite(PIN_BOOST_EN, d > 0 ? HIGH : LOW);
+  if (d > 0) delayMicroseconds(500);               // rail settle on first turn-on
+  ledcWrite(PIN_MIST_PWM, d);
+  Serial.printf("[DUTY] %3u/255 = %5.1f%%\n", d, d * 100.0f / 255.0f);
+}
+
+static void sweep() {
+  Serial.println();
+  Serial.println("[SWEEP] 0 -> 100% duty. WATCH THE MIST at each step and note");
+  Serial.println("[SWEEP] where it stops getting denser. ~3 s per step.");
+  Serial.println("[SWEEP]  step   duty    duty%   current");
+
+  float ma[SWEEP_STEPS + 1];
+  uint8_t duties[SWEEP_STEPS + 1];
+
+  for (uint8_t i = 0; i <= SWEEP_STEPS; i++) {
+    const uint8_t d = (uint8_t)((uint16_t)i * 255 / SWEEP_STEPS);
+    duties[i] = d;
+    digitalWrite(PIN_BOOST_EN, HIGH);
+    ledcWrite(PIN_MIST_PWM, d);
+    delay(SWEEP_SETTLE_MS);                        // let drive + water column respond
+    ma[i] = readMa(SWEEP_DWELL_MS - SWEEP_SETTLE_MS);
+    Serial.printf("[SWEEP]  %2u/%u   %3u   %5.1f%%   %6.1f mA\n",
+                  i, SWEEP_STEPS, d, d * 100.0f / 255.0f, ma[i]);
+    if (Serial.available() && Serial.read() == 'x') { Serial.println("[SWEEP] aborted"); break; }
+  }
+  setDuty(0);
+
+  // Summary: current alone can't see the mist peak (current keeps rising past
+  // it) — so print the table for pairing with what you SAW.
+  Serial.println();
+  Serial.println("[RESULT] duty%, mA   (paste next to your mist notes)");
+  for (uint8_t i = 0; i <= SWEEP_STEPS; i++)
+    Serial.printf("%5.1f, %.1f\n", duties[i] * 100.0f / 255.0f, ma[i]);
+  Serial.println();
+  Serial.println("[RESULT] Reading it: if current rose monotonically but mist");
+  Serial.println("[RESULT] peaked near 50%, the library's 127 cap is correct.");
+  Serial.println("[RESULT] If mist tracked current all the way up, tell Claude");
+  Serial.println("[RESULT] — the cap should be raised.");
+}
+
+static void printHelp() {
+  Serial.println("[HELP] w=auto sweep  0..9=hold n*10% duty  +/-=nudge  s=stream  x=off");
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(1000);
+  pinMode(PIN_CURRENT_ADC, INPUT);
+  pinMode(PIN_BOOST_EN, OUTPUT);
+  digitalWrite(PIN_BOOST_EN, LOW);
+  ledcAttach(PIN_MIST_PWM, MIST_FREQ_HZ, PWM_RES_BITS);
+  ledcWrite(PIN_MIST_PWM, 0);
+
+  Serial.println("==============================================");
+  Serial.println(" Duty Sweep - does mist peak at 50% duty?");
+  Serial.println("==============================================");
+  Serial.println("[!] Disc must be IN WATER before you start.");
+  printHelp();
+}
+
+void loop() {
+  while (Serial.available()) {
+    const char ch = Serial.read();
+    if      (ch == 'w') sweep();
+    else if (ch == 'x') setDuty(0);
+    else if (ch == 's') { g_stream = !g_stream;
+                          Serial.printf("[CFG] stream %s\n", g_stream ? "ON" : "OFF"); }
+    else if (ch == '+') setDuty(g_duty <= 251 ? g_duty + 4 : 255);
+    else if (ch == '-') setDuty(g_duty >= 4 ? g_duty - 4 : 0);
+    else if (ch >= '0' && ch <= '9') setDuty((uint8_t)((ch - '0') * 255 / 10));
+    else if (ch == 'h') printHelp();
+  }
+
+  if (g_stream && millis() - g_lastStreamMs >= 100) {
+    g_lastStreamMs = millis();
+    Serial.printf("duty:%u\tmA:%.1f\n", g_duty, readMa(50));
+  }
+}

--- a/variants/battery-kit/hardware/README.md
+++ b/variants/battery-kit/hardware/README.md
@@ -9,7 +9,19 @@
 
 Schematic PDF export: pending (plot from KiCad: File > Plot > PDF).
 
-## V0.3 changes
+## Version changes
+
+**V0.4** (assembled 2026-06; KiCad files pending import — this folder holds V0.3):
+
+- **TPS2116 ST (mux status) routed to XIAO D8** via an R15 pull-up + R21/R22
+  (100k/150k) divider — HIGH = on USB, LOW = on the cell. The same node drives
+  Q1 to disable the 3V3 LDO whenever USB is present, so the board LDO and the
+  XIAO's own regulator never fight. This is the hardware fix for V0.3's
+  false low-battery shutdowns on USB.
+- **Charge current 500 mA → ~200 mA** (R6 2 kΩ → 5.1 kΩ) — keeps the SOT-23-5
+  charger comfortably inside its thermal budget.
+
+**V0.3:**
 
 - **Battery voltage divider on D1** (`D1_BATT_VOLTAGE`, ratio 2.0) — enables the fuel gauge + graceful low-battery shutdown in firmware.
 


### PR DESCRIPTION
## Battery Kit V0.4: bring-up, duty characterization tools, and docs — release integration

Everything from the V0.4 board-in-hand campaign (2026-07-03), retargeted to main (which already contains the `feature/extension-battery-kits` lineage) and with `origin/main` merged in. Hardened by Codex review — all confirmed findings applied.

### Firmware
- **`BatteryKit_BringUp`**: V0.4 ST (USB/cell) sense on D8, ST-gated battery classification, calibrated `analogReadMilliVolts`, and the **mux-handoff test** — RAM flip counter + `esp_reset_reason()` prove the TPS2116's ~1.3 ms break-before-make survived a live unplug (serial is down during the event, so the sketch replays it on demand).
- **`DutySweep_Test` (new)**: the tool behind the duty characterization — attended sweep, battery sweep ('B'), unattended sweep on any supply ('U'), NVS black-box logging that survives brownouts/power cuts (magic-validated blob), replay gated on an attached serial monitor, dynamic cell-floor guard, sensor-saturation abort, per-board configs (V0.4 / Extension V0.1).

### Measured findings (documented in-repo + docs site)
- Mist output **peaks at ~70% duty** (not 50%); >75% is unstable and declining; 50% remains the efficiency knee and battery-sustainable default
- Supply ceilings: laptop port ~1.5 A hard cut · 2 A brick folds ~2.1 A · charged cell reaches exactly 70% (0.4 Ω source resistance into the 3.5 V LDO floor) · the mux gap is unbridgeable at ~2 A even with a cell attached
- As-built V0.4: ~196 mA charge current, boost rail live from power-on, D8 HIGH ≈ 2.68 V

### Docs (deploys to docs.byproductlab.com on merge)
- **battery-kit page**: V0.4 — D8 was listed as a spare; now documents the ST sense, Q1/LDO interplay, self-gating battery monitoring, measured power budget
- **library page**: v2.0 API incl. power-source sensing + measured duty table
- **how-it-works**: the 50%-duty note replaced with the measured story
- Variant/hardware READMEs: V0.4 changes; note that V0.4 KiCad files are pending import (currently in the project drive)
- .gitignore: `.kicad_prl`, timestamped `.bak-*`, `.claude/worktrees/`

### Verification
`arduino-cli` clean: BringUp (C6+S3) and DutySweep (both board configs). Bench: every tool exercised on real V0.4 + Extension hardware through ~10 sweep runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)