### PR TITLE
Relink Battery Kit V0.3 schematic to reorganized kicad-libraries buckets

### DIFF
--- a/variants/battery-kit/hardware/kicad/MistMaker-Battery-Kit-V0-3.kicad_sch
+++ b/variants/battery-kit/hardware/kicad/MistMaker-Battery-Kit-V0-3.kicad_sch
@@ -852,7 +852,7 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "DavidLib_Mux:TPS2116DRLR"
+		(symbol "DavidLib_Power:TPS2116DRLR"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -880,7 +880,7 @@
 					(justify left top)
 				)
 			)
-			(property "Footprint" "DavidLib_Mux:TPS62932DRLR"
+			(property "Footprint" "DavidLib_Power:TPS62932DRLR"
 				(at 29.21 -94.92 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -1213,7 +1213,7 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "DavidLib_Switch:N_MOSFET_G1003A"
+		(symbol "DavidLib_Discrete:N_MOSFET_G1003A"
 			(pin_names
 				(offset 0)
 				(hide yes)
@@ -5351,7 +5351,7 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Switch_DavidLib:TS-1088-AR02016"
+		(symbol "DavidLib_Switch:TS-1088-AR02016"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
@@ -5379,7 +5379,7 @@
 					(justify left top)
 				)
 			)
-			(property "Footprint" "Switch_DavidLib:TS1088AR02016"
+			(property "Footprint" "DavidLib_Switch:TS1088AR02016"
 				(at 19.05 -94.92 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -15461,7 +15461,7 @@
 		)
 	)
 	(symbol
-		(lib_id "DavidLib_Mux:TPS2116DRLR")
+		(lib_id "DavidLib_Power:TPS2116DRLR")
 		(at 116.84 36.83 0)
 		(unit 1)
 		(body_style 1)
@@ -15491,7 +15491,7 @@
 				)
 			)
 		)
-		(property "Footprint" "DavidLib_Mux:TPS62932DRLR"
+		(property "Footprint" "DavidLib_Power:TPS62932DRLR"
 			(at 146.05 131.75 0)
 			(hide yes)
 			(show_name no)
@@ -20944,7 +20944,7 @@
 		)
 	)
 	(symbol
-		(lib_id "Switch_DavidLib:TS-1088-AR02016")
+		(lib_id "DavidLib_Switch:TS-1088-AR02016")
 		(at 337.82 222.25 0)
 		(unit 1)
 		(body_style 1)
@@ -24431,7 +24431,7 @@
 		)
 	)
 	(symbol
-		(lib_id "DavidLib_Switch:N_MOSFET_G1003A")
+		(lib_id "DavidLib_Discrete:N_MOSFET_G1003A")
 		(at 154.94 153.67 0)
 		(unit 1)
 		(body_style 1)


### PR DESCRIPTION
Preserves the library-nickname relink from `feature/extension-battery-kits` (originally committed 2026-06-23, the only content on that branch that never reached main — the branch is now retired as part of repo cleanup). Cherry-picked clean onto main.

`DavidLib_Mux→DavidLib_Power` (TPS2116), `Switch_DavidLib→DavidLib_Switch` (button), `DavidLib_Switch→DavidLib_Discrete` (MOSFET symbol) — footprint-library reorganization only, no electrical changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)