### PR TITLE
Self-test: water-band ceiling 280 → 450 mA

### DIFF
--- a/variants/battery-kit/firmware/BatteryKit_BringUp/pins.h
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/pins.h
@@ -98,5 +98,11 @@ constexpr float ST_VBAT_MAX_V  = 4.40f;
 constexpr float ST_IDLE_MAX_MA  = 10.0f;   // rail off: INA180 zero + leakage
 constexpr float ST_LOAD_MIN_MA  = 10.0f;   // below at full drive -> no disc
 constexpr float ST_DRY_MIN_MA   = 60.0f;   // 60-115 = dry-disc band
-constexpr float ST_WATER_MIN_MA = 115.0f;  // 115-280 = disc-in-water band
-constexpr float ST_LOAD_MAX_MA  = 280.0f;  // above at 50% duty -> investigate
+constexpr float ST_WATER_MIN_MA = 115.0f;  // 115-450 = disc-in-water band
+// Water-band ceiling: coupling varies with water level/disc seating — a
+// well-coupled disc measured a stable ~372 mA WITH a strong plume (V0.4.1
+// bench, 2026-07-18), vs ~180 mA lighter-coupled minutes earlier on the
+// same board. Real drive-stage faults live much higher (sweep: 480 mA only
+// at 62% duty, ~1.1 A at 75%), so the fault line sits above the healthy
+// coupling range, not at the reference-bench 130-225 plateau.
+constexpr float ST_LOAD_MAX_MA  = 450.0f;  // above at 50% duty -> investigate

--- a/variants/xiao-extension-kit/firmware/ExtensionKit_BringUp/pins.h
+++ b/variants/xiao-extension-kit/firmware/ExtensionKit_BringUp/pins.h
@@ -58,8 +58,13 @@ constexpr uint16_t ST_BTN_WAIT_MS = 5000;   // BOOT-press window (serial start)
 constexpr float ST_IDLE_MAX_MA  = 10.0f;    // PWM off: INA180 zero + leakage
 constexpr float ST_LOAD_MIN_MA  = 10.0f;    // below at full drive -> no disc
 constexpr float ST_DRY_MIN_MA   = 60.0f;    // 60-115 = dry-disc band
-constexpr float ST_WATER_MIN_MA = 115.0f;   // 115-280 = disc-in-water band
-constexpr float ST_LOAD_MAX_MA  = 280.0f;   // above at 50% duty -> investigate
+constexpr float ST_WATER_MIN_MA = 115.0f;   // 115-450 = disc-in-water band
+// Water-band ceiling: coupling varies with wick placement / water level — a
+// well-coupled disc measured a stable ~372 mA WITH a strong plume (V0.4.1
+// bench, 2026-07-18, enclosure swap changed the wick contact), vs ~180 mA
+// lighter-coupled minutes earlier on the same board. Real drive-stage faults
+// live much higher (sweep: 480 mA only at 62% duty, ~1.1 A at 75%).
+constexpr float ST_LOAD_MAX_MA  = 450.0f;   // above at 50% duty -> investigate
 
 // Row results. Lives here (not the .ino) so the Arduino builder's auto-hoisted
 // prototypes see the type. skip = couldn't run, info = no pass criterion,


### PR DESCRIPTION
Calibration follow-up to #30 from first-production-board data: same board, same duty — ~180 mA twice, then a stable ~372 mA **with a strong plume** after an enclosure swap changed the wick's disc contact. Coupling (wick placement/water level) sets the load, so the healthy water band is wider than the reference bench's 130–225 mA; genuine drive-stage faults sit far higher (480 mA @ 62% duty, ~1.1 A @ 75% in the sweep). Ceiling moved 280 → 450 mA in both kits' pins.h (per their edit-both-together rule) + READMEs.

Bench-verified on the production board: self-test **PASS 7/0, LOAD_MA 373.38 mA in [115..450]**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176UKZKuBVRY94h7e6Rjaiu