### PR TITLE
Docs: follow library v2.2 example curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ schematics** live on the [documentation site](https://docs.byproductlab.com/).
    is the easiest first build; the [Battery Kit](https://docs.byproductlab.com/boards/battery-kit/)
    cuts the cord. (Or [buy one assembled and tested](https://shop.byproductlab.com).)
 2. **Flash the variant's BringUp sketch** to verify the hardware feature by feature.
-3. **Install the [MistMaker Arduino library](https://github.com/owochel/MistMaker)** (v1.1+)
-   and work through the examples: `MistBlink` → `MistDimming` → `WaterDetect` →
-   `WiFiPhoneControl` (control it from your phone).
+3. **Install the [MistMaker Arduino library](https://github.com/owochel/MistMaker)** (v2.2+)
+   and work through the examples: `Blink` → `Breath` → `WaterDetect` →
+   `PhoneDemo` (control it from your phone).
 4. **Smart home?** [`firmware-examples/home-assistant/`](firmware-examples/home-assistant/)
-   joins Home Assistant with no code at all (ESPHome), or use the `HomeAssistant_MQTT`
-   library example.
+   joins Home Assistant with no code at all (ESPHome).
 
 ## How it works
 

--- a/docs/boards/battery-kit.md
+++ b/docs/boards/battery-kit.md
@@ -100,8 +100,8 @@ cell is really the source.
 | < 3.45 V | Low | Warn (LED blink / UI banner) |
 | < 3.20 V | Critical | Mist off → boost off → deep sleep |
 
-The `WiFiPhoneControl` and `HomeAssistant_MQTT` examples implement the full
-graceful power-off (two consecutive critical readings, radio off, deep sleep).
+The full graceful power-off pattern (two consecutive critical readings, radio
+off, deep sleep) is documented on the [library page](../library.md).
 
 ## Revision history
 

--- a/docs/boards/extension-kit.md
+++ b/docs/boards/extension-kit.md
@@ -66,8 +66,8 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
 4. Flash
    [`ExtensionKit_BringUp`](https://github.com/Dav1dyang/Programmable-Mist-Maker/tree/main/variants/xiao-extension-kit/firmware/ExtensionKit_BringUp)
    and walk its serial checklist (`h` for help).
-5. Install the [MistMaker library](../library.md) (v1.1+) and try the examples:
-   `MistBlink` → `MistDimming` → `WaterDetect` → `WiFiPhoneControl`.
+5. Install the [MistMaker library](../library.md) (v2.2+) and try the examples:
+   `Blink` → `Breath` → `WaterDetect` → `PhoneDemo`.
 
 In library examples select the board with:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ First presented as a hands-on workshop at the **Open Hardware Summit 2025**.
    under the **Boards** tab.
 2. **Flash the BringUp sketch** for your board to verify the hardware feature by
    feature.
-3. **Install the [MistMaker library](library.md)** (v1.1+) and work through the
-   examples: `MistBlink` → `MistDimming` → `WaterDetect` → `WiFiPhoneControl`.
+3. **Install the [MistMaker library](library.md)** (v2.2+) and work through the
+   examples: `Blink` → `Breath` → `WaterDetect` → `PhoneDemo`.
 4. **Smart home?** The Home Assistant examples need no code at all — see the
    [library page](library.md#examples).
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -111,12 +111,13 @@ Your sketch's `setLevel(0..255)` scale is unaffected by the cap — 255 always m
 
 | Example | What it shows |
 |---|---|
-| `MistBlink` | Hello-world: 6 s ON / 3 s OFF cycle |
-| `MistDimming` | Organic "breathing" mist with `setLevel()` |
-| `WaterDetect` | Disc + water detection, auto-calibration, auto-recovery |
-| `WiFiPhoneControl` | Phone control via WiFi AP + web UI, graceful low-battery shutdown |
-| `HomeAssistant_MQTT` | Native Home Assistant device via MQTT Discovery |
-| `PhoneSensors` | Phone mic / light / motion / face / **music** drive the mist over the internet ([relay + web app included](https://github.com/owochel/MistMaker/tree/main/extras/phone-app)) |
+| `Blink` | Hello-world: mist 6 s on / 3 s off, LED follows |
+| `Breath` | Mist that breathes — smooth fade in, hold, fade out with `setLevel()` |
+| `WaterDetect` | Self-minding mist: stops when water runs out or the disc comes off, resumes by itself |
+| `PhoneDemo` | Phone mic / light / motion / face / **music** drive the mist over the internet ([relay + web app included](https://github.com/owochel/MistMaker/tree/main/extras/phone-app)) |
+
+Retired examples (MQTT/Home Assistant, ESP-NOW, WiFi-AP control) live in the
+[v2.1.0 release](https://github.com/owochel/MistMaker/releases/tag/v2.1.0).
 
 ## Home Assistant without code
 

--- a/firmware-examples/home-assistant/README.md
+++ b/firmware-examples/home-assistant/README.md
@@ -13,10 +13,10 @@ The YAML targets the **Battery Kit V0.3**. For the Extension (BFF) V0.2, delete 
 
 ## Option B — Arduino + MQTT
 
-Prefer to stay in the Arduino ecosystem (or to customize behavior)? Use the **`HomeAssistant_MQTT`** example in the [MistMaker library](https://github.com/owochel/MistMaker) (v1.1+):
+Prefer to stay in the Arduino ecosystem (or to customize behavior)? The **`HomeAssistant_MQTT`** sketch was retired from the library's curated examples in v2.2 — download it from the [v2.1.0 release](https://github.com/owochel/MistMaker/releases/tag/v2.1.0) (`examples/HomeAssistant_MQTT/`), then:
 
 1. Run an MQTT broker (the Mosquitto add-on) and HA's MQTT integration.
-2. `File > Examples > MistMaker > HomeAssistant_MQTT`, fill in WiFi + broker credentials, flash.
+2. Open the sketch, fill in WiFi + broker credentials, flash.
 3. The sketch publishes MQTT Discovery configs — the device appears automatically with mist light, battery %, and water-status entities, plus offline detection via LWT.
 
 ## Automation ideas

--- a/legacy/v1-4/example-code/WithLibrary/README.md
+++ b/legacy/v1-4/example-code/WithLibrary/README.md
@@ -14,8 +14,6 @@
 3. Select the downloaded ZIP file in Arduino IDE.
 
 4. You're done! Now you can access example code via:  
-   `File > Examples > MistMaker > SimpleControl`
-   or
    `File > Examples > MistMaker > Blink`
 
 ---

--- a/variants/battery-kit/README.md
+++ b/variants/battery-kit/README.md
@@ -71,7 +71,7 @@ D1 reads the pack through an equal-resistor divider (ratio 2.0). On USB the node
 | < 3.45 V | Low | Warn (LED blink / UI banner) |
 | < 3.20 V | Critical | Mist off → boost off → deep sleep |
 
-The [MistMaker library](https://github.com/owochel/MistMaker) (v2.1+) wraps this and gates it on the D8 source sense — `batteryState()` returns `CHARGING` on USB and only ever `LOW`/`CRITICAL` on the cell: `batteryState()`, `batteryPercent()`, `usbPresent()`, `shutdown()`. The `WiFiPhoneControl` and `HomeAssistant_MQTT` examples implement the full graceful power-off.
+The [MistMaker library](https://github.com/owochel/MistMaker) (v2.1+) wraps this and gates it on the D8 source sense — `batteryState()` returns `CHARGING` on USB and only ever `LOW`/`CRITICAL` on the cell: `batteryState()`, `batteryPercent()`, `usbPresent()`, `shutdown()`. The library README's battery section shows the full graceful power-off pattern (two consecutive critical readings, radio off, deep sleep).
 
 ## Build your own
 

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/BatteryKit_BringUp.ino
@@ -314,7 +314,7 @@ static void runSelfTest(bool startedByButton) {
                 g_tCount[T_CHECK]);
   Serial.println("[TEST] not covered here (see V04-Acceptance-Test protocol):");
   Serial.println("[TEST]   multimeter Vbatt cross-check | USB-unplug mux handoff (u)");
-  Serial.println("[TEST]   charge-LED behavior | PhoneSensors radio test | duty sweep (DutySweep_Test)");
+  Serial.println("[TEST]   charge-LED behavior | PhoneDemo radio test | duty sweep (DutySweep_Test)");
   Serial.println();
 }
 

--- a/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
+++ b/variants/battery-kit/firmware/BatteryKit_BringUp/README.md
@@ -76,4 +76,4 @@ The TPS2116 switches sources **break-before-make**: for ~1.3 ms neither input dr
 - Charge current is **~196 mA** (R6 = 5.1 kΩ on the LP4060) — a deliberate thermal derate from the 500 mA design. LED1 (green) lit = charging; a 500 mAh cell takes ≈ 3 h from empty.
 - The battery divider (R18/R19) is hard-wired and draws a constant **~210 µA** from the cell — negligible in use, but don't expect shelf-storage battery life with a cell left plugged in.
 
-Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) (≥ 2.1.0) examples — `WiFiPhoneControl` re-enables graceful low-battery shutdown, now gated on the D8 mux status.
+Pass everything? Move on to the [MistMaker library](https://github.com/owochel/MistMaker) (≥ 2.2.0) examples — start with `Blink`; battery monitoring there self-gates on the same D8 mux status this sketch just verified.

--- a/variants/xiao-extension-kit/README.md
+++ b/variants/xiao-extension-kit/README.md
@@ -48,7 +48,7 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
 2. Solder the PH-2.0 piezo connector and XIAO headers.
 3. Mount a XIAO ESP32-C6.
 4. Flash [`firmware/ExtensionKit_BringUp/`](firmware/ExtensionKit_BringUp/) and walk its serial checklist (`h` for help).
-5. Install the [MistMaker library](https://github.com/owochel/MistMaker) (v1.1+) and try the examples: `MistBlink` → `MistDimming` → `WaterDetect` → `WiFiPhoneControl`.
+5. Install the [MistMaker library](https://github.com/owochel/MistMaker) (v2.2+) and try the examples: `Blink` → `Breath` → `WaterDetect` → `PhoneDemo`.
 
 In library examples select the board with:
 


### PR DESCRIPTION
Companion to owochel/MistMaker#6 — every reference to the retired/renamed examples updated (progressions, library page table, HA guide's Arduino path → release download, legacy note, bring-up's PhoneDemo mention). mkdocs --strict + compile verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176UKZKuBVRY94h7e6Rjaiu