### PR TITLE
docs(lab): clarify logic levels vs the 5V power pad

### DIFF
--- a/docs/labs/making-mist-with-an-arduino.md
+++ b/docs/labs/making-mist-with-an-arduino.md
@@ -285,8 +285,12 @@ The same power and heat notes apply.
 ## The Uno vs the Nano 33 IoT vs the Uno R4 vs the Nano 33 BLE
 
 - **Logic levels.** The Uno R3 and R4 are 5 V boards; the Nano 33 IoT and
-  BLE are 3.3 V. The kit accepts both on its inputs, so the same wiring
-  works — but never wire the kit's 5V-in to a Nano output pin.
+  BLE are 3.3 V. The kit's signal pads (D0 and D3) are inputs that accept
+  either, which is why one wiring diagram serves every board here.
+- **The 5V pad is power, not signal.** It feeds the mist driver and draws up
+  to half an amp, so it belongs on your board's 5V supply pin — never on a
+  GPIO. A GPIO can't source that much current, and on a 3.3 V Nano, 5 V on
+  an I/O pin can destroy it.
 - **Mist resolution.** The mist signal has 147 brightness steps on the R3
   and BLE, and 442 on the Nano 33 IoT and R4 (their timers run faster).
   You'll only notice in slow fades at the dimmest levels.


### PR DESCRIPTION
The 'Logic levels' bullet merged two separate facts and ended with "never wire the kit's 5V-in to a Nano output pin" — which reads like an obscure Nano-only rule when the real point applies to every board.

Now split into two bullets:
- **Logic levels** — the kit's signal pads (D0, D3) accept 3.3 V or 5 V, which is why one wiring diagram serves all the boards
- **The 5V pad is power, not signal** — it draws up to half an amp, so it must come from a 5V supply pin, never a GPIO (a GPIO can't source it, and 5 V on a 3.3 V Nano I/O pin can destroy it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)