### PR TITLE
docs(lab): fix dead PWM prerequisite link

### DIFF
--- a/docs/labs/making-mist-with-an-arduino.md
+++ b/docs/labs/making-mist-with-an-arduino.md
@@ -16,7 +16,7 @@ maker needs a very particular kind of pin to work at all.
 
 - [Digital input and output](https://itp.nyu.edu/physcomp/labs/labs-arduino-digital-and-analog/digital-input-and-output-with-an-arduino/)
 - [Analog input](https://itp.nyu.edu/physcomp/labs/labs-arduino-digital-and-analog/analog-in-with-an-arduino/)
-- What [PWM](https://itp.nyu.edu/physcomp/labs/labs-arduino-digital-and-analog/analog-out-with-an-arduino/) is
+- What [PWM](https://itp.nyu.edu/physcomp/lessons/analog-output/) is
 
 ### Things You'll Need
 


### PR DESCRIPTION
The PWM link in *What You'll Need to Know* pointed at `labs/labs-arduino-digital-and-analog/analog-out-with-an-arduino/`, which returns **404**. Replaced with the Analog Output lesson David specified: https://itp.nyu.edu/physcomp/lessons/analog-output/ (verified 200).

The other two prerequisite links (digital I/O, analog in) were checked in the same pass and both resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)