### PR TITLE
Docs: 2026-07 photography, README refresh, and MistMaker 2.6 updates

### DIFF
--- a/docs/boards/battery-kit.md
+++ b/docs/boards/battery-kit.md
@@ -132,8 +132,12 @@ Still open for V0.5: delete C14 (redundant bulk), copy the Extension's U4
 
 From the 2026-07 bench characterization ([full story on the library page](../library.md)):
 
-- **Default drive (50% duty):** ~0.23 A on the 5 V rail, ~0.3 A from the cell —
-  runs cool, sustainable on any supply. This is the library default.
+- **50% duty:** ~0.23 A on the 5 V rail, ~0.3 A from the cell — runs cool,
+  sustainable on any supply. This was the library default through v2.5.
+- **33% duty** is the library default from **v2.6** — bench-tested as a good
+  amount of mist with the tapped inductor staying cool on long runs. It sits
+  below the 50% figures above, so everything here still bounds it; the rail and
+  cell currents at 33% haven't been separately characterized yet.
 - **Peak mist (~70% duty, `DUTY_TURBO`):** ~0.83 A on the rail — wall-adapter
   territory (≥ 2 A recommended); a fully-charged cell can just reach it.
 - The mux switches sources **break-before-make (~1.3 ms)** — a graceful handoff

--- a/docs/boards/extension-kit.md
+++ b/docs/boards/extension-kit.md
@@ -49,9 +49,9 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
                 └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~80 Vpp)
 ```
 
-- The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at 50% duty by
-  default — the efficient cap, not a hard ceiling
-  ([why 50%](../how-it-works.md#the-resonant-drive-5-v-in-80-vpp-out)).
+- The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at 33% duty by
+  default — the thermal sweet spot, not a hard ceiling
+  ([why](../how-it-works.md#the-resonant-drive-5-v-in-80-vpp-out)).
 - The MOSFET switches the tapped-inductor + piezo loop; LC resonance boosts the 5 V
   rail to the ~80 Vpp the disc needs (measured on the V1.4 circuit; same topology here).
 - The **INA180A3** (100 V/V) reads the voltage across a 30 mΩ shunt — 3.0 V per amp

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -33,7 +33,7 @@ these boards adapt:
 5V current ──► 30 mΩ shunt ──► INA180A3 ──► ADC pin
 ```
 
-1. The ESP32 outputs a **108.7 kHz PWM** (50% duty by default) into a gate driver + MOSFET.
+1. The ESP32 outputs a **108.7 kHz PWM** (33% duty by default) into a gate driver + MOSFET.
 2. The MOSFET rapidly switches the tapped inductor in a loop with the disc's own
    capacitance, forming an **LC tank** that rings at the drive frequency.
 3. The inductor is *tapped* — three legs, roughly a **28 µH : 800 µH** winding ratio —
@@ -43,14 +43,16 @@ these boards adapt:
    resonance — which is exactly why `setLevel()` (PWM duty) modulates mist like a
    dimmer.
 
-    !!! info "Why 50% duty, and where the real maximum is (measured 2026-07)"
+    !!! info "Why the default is well under the maximum (measured 2026-07)"
         Longer on-time stores more energy in the inductor, but the resonant
         "ring-back" needs about half of each 9.2 µs cycle to swing — so past 50%
         duty the ring gets clipped and efficiency collapses. A full 0→90% duty
         sweep on V0.4 hardware found mist output actually **peaks near 70% duty**
         at ~4× the input power of the 50% point, then declines and turns unstable.
-        The library defaults to the efficient 50% cap and exposes the measured
-        peak as `DUTY_TURBO` — see the [library page](library.md).
+        The library defaults to a **33% cap** — bench-tested as a good amount of
+        mist with the tapped inductor staying cool on long runs — and exposes the
+        measured peak as `DUTY_TURBO`. Both are one call away; see the
+        [library page](library.md#how-hard-can-it-drive-measured).
 5. As a bonus, the current flowing through a 30 mΩ shunt (read by an INA180A3,
    3.0 V/A) differs measurably between *no disc*, *dry disc*, and *disc in water* —
    one ADC pin gives disc detection and a water sensor for free.

--- a/docs/labs/making-mist-with-an-arduino.md
+++ b/docs/labs/making-mist-with-an-arduino.md
@@ -340,7 +340,10 @@ if (mist.buttonPressed()) mist.turnOn();
 else                      mist.turnOff();
 ```
 
-The **ButtonPressToMist** and **ButtonOn-Off** examples build on this.
+The **ToggleSwitch** and **PushButton** examples build on this — `ToggleSwitch`
+follows the level like the snippet above (a latching switch runs the mist until
+you flip it off), while `PushButton` debounces the press edge so each press of a
+momentary button flips the mist on or off.
 
 ### Everything Wired
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -120,6 +120,24 @@ The duty cap was bench-characterized on real V0.4 hardware (2026-07 sweep, 0→9
 Your sketch's `setLevel(0..255)` scale is unaffected by the cap — 255 always means
 "my current maximum."
 
+!!! note "`setLevel()` is a ratio of the cap, not a clamp against it"
+    The level is rescaled onto the cap — `duty = level / 255 × dutyMax` — so
+    raising the cap makes **every** level stronger, not just the ones that used to
+    clip:
+
+    | `setLevel()` | duty at the default cap (127) | duty at `DUTY_TURBO` (178) |
+    |---|---|---|
+    | 255 | 127 (50%) | 178 (70%) |
+    | 128 | 64 (~25%) | 89 (~35%) |
+    | 64 | 32 (~13%) | 45 (~18%) |
+
+    So `setLevel(128)` means "half of what this board is currently allowed to
+    make," not a fixed 25% duty. `setMaxDuty()` re-applies the current level
+    immediately, so changing it mid-mist takes effect at once. Two edges worth
+    knowing: `setLevel(0)` is special-cased to `turnOff()` (it drops the enable
+    pin and LED, not just duty), and any nonzero level floors at `duty = 1`, so a
+    low level can never silently round down to off.
+
 ## Examples
 
 `File → Examples → MistMaker` — work through them in order:

--- a/docs/library.md
+++ b/docs/library.md
@@ -11,7 +11,16 @@ Arduino IDE → **Library Manager** → search "MistMaker", or clone
 
 Minimum version depends on your board: **v2.1+** for the
 [Battery Kit](boards/battery-kit.md) and [Legacy V1.4](boards/legacy-v1-4.md),
-**v2.2+** for the [Extension Kit](boards/extension-kit.md). Newest is always safe.
+**v2.2+** for the [Extension Kit](boards/extension-kit.md), **v2.5+** to drive a kit
+from an [Arduino over jumper wires](labs/making-mist-with-an-arduino.md). Newest is
+always safe.
+
+!!! warning "v2.6 changed how hard the boards drive by default"
+    The default duty cap dropped from 127 (50%) to **85 (33%)** — bench-tested as a
+    good amount of mist with the tapped inductor staying cool on long runs. Because
+    [`setLevel()` is a ratio of the cap](#how-hard-can-it-drive-measured), **every
+    level now drives ~33% less than on v2.5.x**, not just the top end. To get the
+    old output back, set the cap explicitly: `mist.setMaxDuty(127);`
 
 Every tuning value the library assumes lives in one documented place:
 `namespace MistMakerDefaults` at the top of `MistMaker.h`.
@@ -113,7 +122,8 @@ The duty cap was bench-characterized on real V0.4 hardware (2026-07 sweep, 0→9
 
 | Cap | What you get |
 |---|---|
-| **default (50% duty)** | ~90% of practical mist at ~¼ of peak power; cool components; battery-sustainable. |
+| **default (33% duty, cap 85)** | The thermal sweet spot: a good amount of mist with the tapped inductor staying cool over long runs; easily battery-sustainable. |
+| 50% duty (cap 127) | The pre-2.6 default. More mist, still safe; ~0.23 A on the 5 V rail, ~0.3 A from the cell. `mist.setMaxDuty(127)`. |
 | `mist.setMaxDuty(MistMakerDefaults::DUTY_TURBO)` (**~70%**) | The measured **true mist maximum** — ~4× the input power; wall adapter (≥ 2 A) territory. |
 | above ~75% | Mist *declines* and turns unstable while current climbs — the library hard-limits at 90% of full scale. |
 
@@ -125,14 +135,14 @@ Your sketch's `setLevel(0..255)` scale is unaffected by the cap — 255 always m
     raising the cap makes **every** level stronger, not just the ones that used to
     clip:
 
-    | `setLevel()` | duty at the default cap (127) | duty at `DUTY_TURBO` (178) |
+    | `setLevel()` | duty at the default cap (85) | duty at `DUTY_TURBO` (178) |
     |---|---|---|
-    | 255 | 127 (50%) | 178 (70%) |
-    | 128 | 64 (~25%) | 89 (~35%) |
-    | 64 | 32 (~13%) | 45 (~18%) |
+    | 255 | 85 (33%) | 178 (70%) |
+    | 128 | 43 (~17%) | 89 (~35%) |
+    | 64 | 21 (~8%) | 45 (~18%) |
 
     So `setLevel(128)` means "half of what this board is currently allowed to
-    make," not a fixed 25% duty. `setMaxDuty()` re-applies the current level
+    make," not a fixed duty. `setMaxDuty()` re-applies the current level
     immediately, so changing it mid-mist takes effect at once. Two edges worth
     knowing: `setLevel(0)` is special-cased to `turnOff()` (it drops the enable
     pin and LED, not just duty), and any nonzero level floors at `duty = 1`, so a

--- a/variants/battery-kit/hardware/Duty-Cycle-Research_2026-07-03.md
+++ b/variants/battery-kit/hardware/Duty-Cycle-Research_2026-07-03.md
@@ -88,6 +88,13 @@ lost and switching losses rise (98.4% efficiency at D = 0.5 with optimum load)
 
 ## Practical guidance
 
+> **Superseded on point 1 (2026-08):** the library default moved to
+> `dutyMax = 85` (33%) in MistMaker v2.6 after bench testing found it gives a
+> good amount of mist with L1 staying cool on long runs. That is consistent with
+> this sweep's mist-per-watt finding above (peaks at or below 50%) — it moves the
+> default toward that peak rather than away from it. The rest of this memo stands
+> as measured; it is kept unedited as the 2026-07-03 record.
+
 1. **Keep `dutyMax = 127` as the library default** (efficiency, USB budget,
    L1 thermals, brownout margin).
 2. A supervised **"turbo" band ~143–160 (56–63%)** exists for short bursts on

--- a/variants/xiao-extension-kit/README.md
+++ b/variants/xiao-extension-kit/README.md
@@ -25,7 +25,7 @@ XIAO USB-C 5V ──┬─► UCC27511 gate driver ─► DMT10H009 MOSFET ─�
                 └─► 30 mΩ shunt ─► INA180A3 ─► D2 (analog)          5 V to ~80 Vpp)
 ```
 
-- The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at 50% duty by default — the efficient cap, not a hard ceiling ([why 50%](https://docs.byproductlab.com/how-it-works/#the-resonant-drive-5-v-in-80-vpp-out)).
+- The ESP32 outputs a **108.7 kHz PWM** (the disc's resonant frequency) at 33% duty by default — the thermal sweet spot, not a hard ceiling ([why](https://docs.byproductlab.com/how-it-works/#the-resonant-drive-5-v-in-80-vpp-out)).
 - The MOSFET switches the tapped-inductor + piezo loop; LC resonance boosts the 5 V rail to the ~80 Vpp the disc needs (measured on the Legacy V1.4 circuit; same topology here).
 - The **INA180A3** (100 V/V) reads the voltage across a 30 mΩ shunt — 3.0 V per amp into D2. A dry disc draws visibly less than a wet one, which is how disc-presence and water-level detection work.
 


### PR DESCRIPTION
## What this does

Second half of the docs refresh. PR #45 merged the site changes; this carries the README photography that was cut from it, plus a photo-grid fix and the doc updates that follow MistMaker 2.6.

## Photography

- **Root README** leads with the same Battery Kit shot the docs home page opens with, and gains a two-up of the shipping boards under the boards table. Images resolve from `docs/assets/photos/` so one photo set backs both the README and the docs site.
- **Variant READMEs** get one photo each — Battery Kit V0.4.1 top, Extension Kit V0.1 top, the Block Kit OHS 2026 demo desk, the V1.4 board on legacy — plus docs-site and shop links.
- Root `assets/` is kept: it still holds the design-progress GIFs and the Legacy V1.4 photos the docs reference. The repo map now distinguishes the two.

## Photo-grid fix

The board-photo rows used `repeat(auto-fit, minmax(200px, 1fr))`. `auto-fit` picks column count from **container** width, so two images silently wrapped to one per row whenever the content column fell under ~410px — which moves with zoom, window width, and the Material sidebars, hence the inconsistency. Replaced with `grid-auto-flow: column` (deterministic single row) plus an explicit phone breakpoint to stack.

## Following MistMaker 2.6

Mirrors owochel/MistMaker#9:

- The default duty cap is now 33%, and `library.md` carries a migration warning since `setLevel()` is a ratio of the cap — this changes drive at every level, not just the ceiling.
- `setLevel()` ratio behaviour documented with the same table used in the library README, so the two cannot drift.
- The Labs page follows the `ToggleSwitch` / `PushButton` example rename.
- Adds v2.5+ as the minimum for driving a kit from an Arduino, which was missing from the install list.

**Battery Kit's power budget keeps its measured 0.23 A / 0.3 A figures attached to 50% duty**, where they were actually taken, and says plainly that 33% has not been separately characterized. Scaling measured numbers to a duty they were not measured at would have been worse than the gap — worth a bench pass.

The 2026-07-03 duty-cycle research memo recommended keeping 127. It is left unedited as the dated record with a superseding note; its own mist-per-watt finding (peaks at or below 50%) actually supports the new default.

## Fixes found along the way

- `battery-kit` and `xiao-extension-kit` READMEs both linked `../../README.md#enclosures` — an anchor that has never existed
- `block-kit` README was titled "Block Kit" while every other surface says V0.1, and did not mention the OHS 2026 demo
- `i2c-multipack-kit` had no pointer to its docs page
- "cotton wick sticks" → "cotton sticks", matching the docs

## Verification

`mkdocs build --strict` clean. All README image paths and relative `.md` links resolve; all referenced docs and shop URLs return 200. Rebased onto current `main` after PR #45 merged — the only overlap was the `mkdocs.yml` nav, where both the `Labs:` section and `battery-kit-enclosure.md` are present.

## Note

The enclosure part names on the Enclosure & Assembly page are read from the photos, not from CAD — worth a check before this is public. The page also states the STLs are not published yet, since `variants/battery-kit/enclosure/` is still a `.gitkeep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
